### PR TITLE
Implements upserts.

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -10,6 +10,8 @@ function getCollection(clientReqMsg) {
   return eval('that.mocks.' + clientReqMsg.fullCollectionName);
 }
 
+// Determines whethe value is an atomic value (i.e., not an object or an
+// array).
 function isAtomic(value) {
   if (typeof value === 'number') {
     return true;
@@ -23,10 +25,49 @@ function isAtomic(value) {
   return false;
 }
 
+// Determines whether a value is an operator (i.e., starts with a $ sign).
+// Assumes the value is a string.
 function isOperator(value) {
   return value.length > 0 && value[0] === '$';
 }
 
+// Assuming source is a MongoDB selector document, retrieves values from
+// equality comparisons (e,g, {a: 1}) and set them in destination.  If source
+// contains the $and operator, recurses over its arguments. E.g.,
+//   var doc = {};
+//   copyEqualityValues(doc, {a: 1, $and: [{b: 2}, {$and: [c: 5, 'd.e': 6]}]});
+// will make doc equal {a: 1, b: 2, c: 5, d: {e: 6}}.
+//
+function copyEqualityValues(destination, source) {
+  _.forOwn(source, function(value, key) {
+    if (!isOperator(key)) {
+      if (isAtomic(value)) {
+        if (!isOperator(value)) {
+          wrapElementForAccess(destination, key).setValue(value);
+        }
+      } else {
+        copyEqualityValues(destination, value);
+      }
+    } else if (key === '$and') {
+      _.forEach(value, function(elem) {
+        copyEqualityValues(destination, elem);
+      });
+    }
+  });
+}
+
+// Wraps an element of doc accessible via path in the dot notation
+// (http://docs.mongodb.org/manual/core/document/#document-dot-notation) in a
+// handler object that allows getting or setting the value of the element.  For
+// example, wrapElementForAccess({a: {b: 1}}, 'a.b').getValue() will return 1.
+// When getting a value, if leaf or intermediate children do not exist, the
+// result will be undefined. For example, wrapElementForAccess({a}, 'b') will
+// return undefined.  When setting a value which parent does not exists, the
+// parent will be created. For example, after running this code:
+//   var doc = {a: 1};
+//   wrapElementForAccess(doc, 'b.c').setValue(5);
+// doc will be {a: 1, b: {c: 5}}.
+//
 function wrapElementForAccess(doc, path) {
   var formatDocTraversErrorMessage = function(selector) {
     return util.format(
@@ -286,12 +327,24 @@ that = {
 
     var literalSubfield = _.findKey(
       clientReqMsg.update,
-      function(value, key) { return !isOperator(key) && _.contains(key, '.'); });
+      function(value, key) {
+        return !isOperator(key) && _.contains(key, '.');
+      });
     if (literalSubfield) {
       that.lastError = util.format(
         "can't have . in field names [%s]",
         literalSubfield);
       return;
+    }
+    var upsertedDoc;
+    if (docs.length === 0 && clientReqMsg.flags.upsert) {
+      upsertedDoc = {};
+      if (updateContainsOperators) {
+        copyEqualityValues(upsertedDoc, clientReqMsg.selector);
+      }
+      collection.push(upsertedDoc);
+      docs = [upsertedDoc];
+      // Now allow the update loop to update the newly inserted element.
     }
     _.forEach(docs, function (doc, index) {
       if (!clientReqMsg.flags.multiUpdate && index > 0) {
@@ -315,6 +368,7 @@ that = {
         });
       }
       for (updateKey in clientReqMsg.update) {
+        // TODO(vladlosev): implement $setOnInsert.
         if (updateKey === '$set' ||
             updateKey === '$inc' ||
             updateKey === '$pull') {
@@ -373,6 +427,9 @@ that = {
         }
       }
     });
+    if (upsertedDoc && !('_id' in upsertedDoc)) {
+      upsertedDoc._id = new ObjectID();
+    }
   }
 };
 

--- a/test/testInProcess.js
+++ b/test/testInProcess.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var util = require('util')
   , chai = require('chai')
   , path = require('path')
@@ -93,9 +94,9 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
   describe('find', function() {
     it('run twice', function(done) {
       config.mocks.fakedb.simpleitems = [{key: 'value1'}, {key: 'value2'}];
-      SimpleItem.find(function (err, items) {});
-      SimpleItem.find(function (err, items) {
-        expect(err).to.not.exist;
+      SimpleItem.find(function (error, items) {});
+      SimpleItem.find(function (error, items) {
+        if (error) return done(error);
         expect(items).to.have.length(2);
         expect(items[0]).to.have.property('key', 'value1');
         expect(items[1]).to.have.property('key', 'value2');
@@ -107,8 +108,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
   describe('delete', function() {
     it('basic', function(done) {
       config.mocks.fakedb.simpleitems = [{key: 'value1'}, {key: 'value2'}];
-      SimpleItem.remove({key: 'value1'}, function(err) {
-        expect(err).to.not.exist;
+      SimpleItem.remove({key: 'value1'}, function(error) {
+        if (error) return done(error);
         expect(config.mocks.fakedb.simpleitems).to.have.length(1);
         expect(config.mocks.fakedb.simpleitems[0])
           .to.have.property('key', 'value2');
@@ -118,8 +119,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
 
     it('by query', function(done) {
       config.mocks.fakedb.simpleitems = [{key: 'value1'}, {key: 'value2'}];
-      SimpleItem.remove({key: {$ne: 'value1'}}, function(err) {
-        expect(err).to.not.exist;
+      SimpleItem.remove({key: {$ne: 'value1'}}, function(error) {
+        if (error) return done(error);
         expect(config.mocks.fakedb.simpleitems).to.have.length(1);
         expect(config.mocks.fakedb.simpleitems[0])
           .to.have.property('key', 'value1');
@@ -133,8 +134,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     it('basic', function(done) {
       config.mocks.fakedb.simpleitems = [];
       var item = new SimpleItem({key: 'value'});
-      item.save(function(err) {
-        expect(err).to.not.exist;
+      item.save(function(error) {
+        if (error) return done(error);
         expect(config.mocks.fakedb.simpleitems).to.have.length(1);
         expect(config.mocks.fakedb.simpleitems[0])
           .to.have.property('key', 'value');
@@ -220,12 +221,12 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     it('push to array', function(done) {
       var id = new mongoose.Types.ObjectId;
       config.mocks.fakedb.arrayitems = [{_id: id, __v: 0, key: ['value1']}];
-      ArrayItem.findOne({_id: id}, function (err, item) {
-        expect(err).to.not.exist;
+      ArrayItem.findOne({_id: id}, function (error, item) {
+        if (error) return done(error);
         expect(item).to.have.property('key');
         item.key.push('value2');
-        item.save(function(err) {
-          expect(err).to.not.exist;
+        item.save(function(error) {
+          if (error) return done(error);
           expect(config.mocks.fakedb.arrayitems).to.have.length(1);
           expect(config.mocks.fakedb.arrayitems[0])
             .to.have.property('key')
@@ -252,12 +253,12 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     it('array shift', function(done) {
       var id = new mongoose.Types.ObjectId;
       config.mocks.fakedb.arrayitems = [{_id: id, __v: 0, key: ['value1', 'value2']}];
-      ArrayItem.findOne({_id: id}, function (err, item) {
-        expect(err).to.not.exist;
+      ArrayItem.findOne({_id: id}, function (error, item) {
+        if (error) return done(error);
         expect(item).to.have.property('key');
         item.key.shift();
-        item.save(function(err) {
-          expect(err).to.not.exist;
+        item.save(function(error) {
+          if (error) return done(error);
           expect(config.mocks.fakedb.arrayitems).to.have.length(1);
           expect(config.mocks.fakedb.arrayitems[0])
             .to.have.property('key')
@@ -270,12 +271,12 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     it('set array value', function(done) {
       var id = new mongoose.Types.ObjectId;
       config.mocks.fakedb.arrayitems = [{_id: id, __v: 0, key: ['value1', 'value2']}];
-      ArrayItem.findOne({_id: id}, function (err, item) {
-        expect(err).to.not.exist;
+      ArrayItem.findOne({_id: id}, function (error, item) {
+        if (error) return done(error);
         expect(item).to.have.property('key');
         item.key = ['one', 'two'];
-        item.save(function(err) {
-          expect(err).to.not.exist;
+        item.save(function(error) {
+          if (error) return done(error);
           expect(config.mocks.fakedb.arrayitems).to.have.length(1);
           expect(config.mocks.fakedb.arrayitems[0])
             .to.have.property('key')
@@ -292,12 +293,12 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       config.mocks.fakedb.dateitems = [
         {_id: id, date: tenSecondsAgo}];
       var DateItem = mongoose.connection.model('DateItem');
-      DateItem.findOne({_id: id}, function (err, item) {
-        expect(err).to.not.exist;
+      DateItem.findOne({_id: id}, function (error, item) {
+        if (error) return done(error);
         expect(item).to.have.property('date');
         item.date = now;
-        item.save(function(err) {
-          expect(err).to.not.exist;
+        item.save(function(error) {
+          if (error) return done(error);
           expect(config.mocks.fakedb.dateitems).to.have.length(1);
           expect(config.mocks.fakedb.dateitems[0].date.toString())
             .equal(now.toString());
@@ -313,12 +314,12 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       config.mocks.fakedb.datearrayitems = [
         {_id: id, date: tenSecondsAgo}];
       var DateArrayItem = mongoose.connection.model('DateArrayItem');
-      DateArrayItem.findOne({_id: id}, function (err, item) {
-        expect(err).to.not.exist;
+      DateArrayItem.findOne({_id: id}, function (error, item) {
+        if (error) return done(error);
         expect(item).to.have.property('date');
         item.date = [now];
-        item.save(function(err) {
-          expect(err).to.not.exist;
+        item.save(function(error) {
+          if (error) return done(error);
           expect(config.mocks.fakedb.datearrayitems).to.have.length(1);
           expect(config.mocks.fakedb.datearrayitems[0])
             .to.have.deep.property('date[0]');
@@ -331,8 +332,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
 
     it('$pull', function(done) {
       config.mocks.fakedb.arrayitems = [{key: ['value1', 'value2']}];
-      ArrayItem.update({}, {$pull: {key: 'value1'}}, function(err) {
-        expect(err).to.not.exist;
+      ArrayItem.update({}, {$pull: {key: 'value1'}}, function(error) {
+        if (error) return done(error);
         expect(config.mocks.fakedb.arrayitems).to.have.length(1);
         expect(config.mocks.fakedb.arrayitems[0])
           .to.deep.equal({key: ['value2']});
@@ -345,8 +346,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       var idCopy = new mongoose.Types.ObjectId(id.toString());
       config.mocks.fakedb.arrayobjectiditems = [{key: [id]}];
       ArrayObjectIdItem = mongoose.connection.model('ArrayObjectIdItem');
-      ArrayObjectIdItem.update({}, {$pull: {key: idCopy}}, function(err) {
-        expect(err).to.not.exist;
+      ArrayObjectIdItem.update({}, {$pull: {key: idCopy}}, function(error) {
+        if (error) return done(error);
         expect(config.mocks.fakedb.arrayobjectiditems).to.have.length(1);
         expect(config.mocks.fakedb.arrayobjectiditems[0])
           .to.deep.equal({key: []});
@@ -356,8 +357,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
 
     it('$pull multiple fields', function(done) {
       config.mocks.fakedb.arrayitems = [{key: ['a', 'b'], key2: ['c', 'd']}];
-      ArrayItem.update({}, {$pull: {key: 'a', key2: 'd'}}, function(err) {
-        expect(err).to.not.exist;
+      ArrayItem.update({}, {$pull: {key: 'a', key2: 'd'}}, function(error) {
+        if (error) return done(error);
         expect(config.mocks.fakedb.arrayitems).to.have.length(1);
         expect(config.mocks.fakedb.arrayitems[0])
           .to.deep.equal({key: ['b'], key2: ['c']});
@@ -396,10 +397,115 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     });
 
     describe('upsert', function() {
-      xit('updates existing documents', function(done) {
+      var id1 = new mongoose.Types.ObjectId();
+      var id2 = new mongoose.Types.ObjectId();
+
+      it('updates existing documents', function(done) {
+        config.mocks.fakedb.freeitems = [{a: 'value', b: 1, _id: id1}];
+        FreeItem.collection.update(
+          {a: 'value'},
+          {'$set': {a: 'new value'}, '$inc': {b: 10}},
+          {upsert: true},
+          function(err) {
+            if (err) return done(err);
+            expect(config.mocks.fakedb.freeitems)
+              .to.deep.equal([{a: 'new value', b: 11, _id: id1}]);
+            done();
+        });
       });
 
-      xit('inserts new document when no matches', function(done) {
+      it('inserts new document when no matches', function(done) {
+        config.mocks.fakedb.freeitems = [{a: 'value1', b: 1, _id: id1}];
+        FreeItem.collection.update(
+          {a: 'value2'},
+          {b: 10},
+          {upsert: true},
+          function(error) {
+            if (error) return done(error);
+            expect(config.mocks.fakedb.freeitems).to.have.length(2);
+            expect(config.mocks.fakedb.freeitems[0])
+              .to.deep.equal({a: 'value1', b: 1, _id: id1});
+            var newDocument = config.mocks.fakedb.freeitems[1];
+            expect(newDocument)
+              .to.have.deep.property('_id.constructor.name', 'ObjectID');
+            expect(newDocument).to.have.property('b', 10);
+            done();
+        });
+      });
+
+      it('uses only update document values if update contains no operators',
+        function(done) {
+          config.mocks.fakedb.freeitems = [{a: 'value1', b: 1, _id: id1}];
+          FreeItem.collection.update(
+            {a: 'value2'},
+            {b: 10, c: 'whatever'},
+            {upsert: true},
+            function(error) {
+              if (error) return done(error);
+              expect(config.mocks.fakedb.freeitems).to.have.length(2);
+              expect(config.mocks.fakedb.freeitems[0])
+                .to.deep.equal({a: 'value1', b: 1, _id: id1});
+              var newDocument = config.mocks.fakedb.freeitems[1];
+              expect(newDocument)
+                .to.have.deep.property('_id.constructor.name', 'ObjectID');
+              expect(_.omit(newDocument, '_id'))
+                .to.deep.equal({b: 10, c: 'whatever'});
+              done();
+          });
+      });
+
+      it('uses update and find document values if update contains operators',
+        function(done) {
+          config.mocks.fakedb.freeitems = [{a: 'value1', b: 1, _id: id1}];
+          FreeItem.collection.update(
+            {a: 'value2', b: {'$gt': 5}},
+            {'$set': {c: 10}, d: 'whatever'},
+            {upsert: true},
+            function(error) {
+              if (error) return done(error);
+              expect(config.mocks.fakedb.freeitems).to.have.length(2);
+              expect(config.mocks.fakedb.freeitems[0])
+                .to.deep.equal({a: 'value1', b: 1, _id: id1});
+              var newDocument = config.mocks.fakedb.freeitems[1];
+              expect(newDocument)
+                .to.have.deep.property('_id.constructor.name', 'ObjectID');
+              // Non-equality comparison should not be a basis for the new
+              // document.
+              expect(_.omit(newDocument, '_id'))
+                .to.deep.equal({a: 'value2', c: 10, d: 'whatever'});
+              done();
+          });
+      });
+
+      it('pulls values from $and conjunctions if update contains operators',
+        function(done) {
+          config.mocks.fakedb.freeitems = [{a: 'value1', b: 1, _id: id1}];
+          FreeItem.collection.update(
+            {'$and': [
+              {a: 'value2', b: 18},
+              {'$and': [{c: 42}, {'d.e': 36}]},
+              {'$or': [{m: 4458}, {n: 5577}]}]},
+            {'$set': {z: 'whatever'}},
+            {upsert: true},
+            function(error) {
+              if (error) return done(error);
+              expect(config.mocks.fakedb.freeitems).to.have.length(2);
+              expect(config.mocks.fakedb.freeitems[0])
+                .to.deep.equal({a: 'value1', b: 1, _id: id1});
+              var newDocument = config.mocks.fakedb.freeitems[1];
+              expect(newDocument)
+                .to.have.deep.property('_id.constructor.name', 'ObjectID');
+              // Equalities under $or should not get transplanted to a new
+              // document, so the result should not contain m or n.
+              expect(_.omit(newDocument, '_id'))
+                .to.deep.equal({
+                  a: 'value2',
+                  b: 18,
+                  c: 42,
+                  d: {e: 36},
+                  z: 'whatever'});
+              done();
+          });
       });
     });
 
@@ -414,8 +520,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
         FreeItem.collection.update(
           {a: 'value'},
           {'$set': {a: 'new value'}, '$inc': {b: 10}},
-          function(err) {
-            if (err) return done(err);
+          function(error) {
+            if (error) return done(error);
             expect(config.mocks.fakedb.freeitems)
               .to.deep.equal([
                 {a: 'new value', b: 11, _id: id1},
@@ -432,8 +538,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
           {a: 'value'},
           {'$set': {a: 'new value'}, '$inc': {b: 10}},
           {multi: false},
-          function(err) {
-            if (err) return done(err);
+          function(error) {
+            if (error) return done(error);
             expect(config.mocks.fakedb.freeitems)
               .to.deep.equal([
                 {a: 'new value', b: 11, _id: id1},
@@ -450,8 +556,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
           {a: 'value'},
           {'$set': {a: 'new value'}, '$inc': {b: 10}},
           {multi: true},
-          function(err) {
-            if (err) return done(err);
+          function(error) {
+            if (error) return done(error);
             expect(config.mocks.fakedb.freeitems)
               .to.deep.equal([
                 {a: 'new value', b: 11, _id: id1},
@@ -484,8 +590,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     it('returns the number of queried documents', function(done) {
       config.mocks.fakedb.numberitems = [{key: 1}, {key: 2}, {key: 3}];
       NumberItem = mongoose.connection.model('NumberItem');
-      NumberItem.count({key: {$gt: 1}}, function(err, n) {
-        expect(err).to.not.exist;
+      NumberItem.count({key: {$gt: 1}}, function(error, n) {
+        if (error) return done(error);
         expect(n).to.equal(2);
         done();
       });


### PR DESCRIPTION
@corydobson, @parkr, @MrNice
This is the last change in the series. It implements the `upsert` option for `update` as described in MongoDB [docs](http://docs.mongodb.org/manual/reference/method/db.collection.update/#upsert-option).
