### PR TITLE
Adds support for $query in find operations.

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -238,9 +238,13 @@ that = {
     var collection, docs, replyBuf;
     logger.trace('doQuery');
     collection = getCollection(clientReqMsg);
+    var query = clientReqMsg.query;
+    if ('$query' in query) {
+      query = query.$query;
+    }
     try {
-      if (clientReqMsg.query && !helper.isEmpty(clientReqMsg.query)) {
-        docs = filter.filterItems(collection, clientReqMsg.query);
+      if (query && !helper.isEmpty(query)) {
+        docs = filter.filterItems(collection, query);
       } else {
         docs = collection || [];
       }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "lodash": "~2.4.1"
   },
   "devDependencies": {
-    "mongoose": "3.6.11",
     "mocha": "~1.21.4",
+    "mongoose": "~3.8.18",
     "chai": "~1.9.1"
   }
 }

--- a/test/testInProcess.js
+++ b/test/testInProcess.js
@@ -103,6 +103,19 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
         done();
       });
     });
+
+    it('supports $query', function(done) {
+      config.mocks.fakedb.freeitems = [
+      {key: 'value', key2: 2, _id: new mongoose.Types.ObjectId()},
+      {key: 'value', key2: 1, _id: new mongoose.Types.ObjectId()}];
+      FreeItem.collection.find({key: 'value'})
+        .sort({key2: 1})  // Calling sort causes MongoDB client to send $query.
+        .toArray(function(error, results) {
+          if (error) return done(error);
+          expect(results).to.have.length(2);
+          done();
+      });
+    });
   });
 
   describe('delete', function() {


### PR DESCRIPTION
@parkr @corydobson This adds support for `$query` [operator](http://docs.mongodb.org/manual/reference/operator/meta/query/) in find operations. The MongoDB client uses `$query` when the `sort` method is invoked on the cursor.
