### PR TITLE
Moves update code into a separate module.

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -44,6 +44,13 @@ that = {
     }
     return dest;
   },
+
+  // Determines whether a value is an operator (i.e., starts with a $ sign).
+  // Assumes the value is a string.
+  isOperator: function(value) {
+    return value.length > 0 && value[0] === '$';
+  },
+
   isEmpty: function (obj) {
     for (var prop in obj) {
       if (obj.hasOwnProperty(prop)) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -4,158 +4,15 @@ var util = require('util')
   , helper = require('./helper')
   , filter = require('./filter')
   , logger;
-var ObjectID = require('bson').ObjectID;
+var update = require('./update');
 
 function getCollection(clientReqMsg) {
   return eval('that.mocks.' + clientReqMsg.fullCollectionName);
 }
 
-// Determines whethe value is an atomic value (i.e., not an object or an
-// array).
-function isAtomic(value) {
-  if (typeof value === 'number') {
-    return true;
-  } else if (typeof value === 'string') {
-    return true;
-  } else if (value instanceof Date) {
-    return true;
-  } else if (value instanceof ObjectID) {
-    return true;
-  } else if (value === null) {
-    return true;
-  }
-  return false;
-}
-
-// Determines whether a value is an operator (i.e., starts with a $ sign).
-// Assumes the value is a string.
-function isOperator(value) {
-  return value.length > 0 && value[0] === '$';
-}
-
-// Assuming source is a MongoDB selector document, retrieves values from
-// equality comparisons (e,g, {a: 1}) and set them in destination.  If source
-// contains the $and operator, recurses over its arguments. E.g.,
-//   var doc = {};
-//   copyEqualityValues(doc, {a: 1, $and: [{b: 2}, {$and: [c: 5, 'd.e': 6]}]});
-// will make doc equal {a: 1, b: 2, c: 5, d: {e: 6}}.
-//
-function copyEqualityValues(destination, source) {
-  _.forOwn(source, function(value, key) {
-    if (!isOperator(key)) {
-      if (isAtomic(value)) {
-        if (!isOperator(value)) {
-          wrapElementForAccess(destination, key).setValue(value);
-        }
-      } else {
-        copyEqualityValues(destination, value);
-      }
-    } else if (key === '$and') {
-      _.forEach(value, function(elem) {
-        copyEqualityValues(destination, elem);
-      });
-    }
-  });
-}
-
-function InputDataError(message) {
-  this.message = message;
-}
-InputDataError.prototype = new Error();
-
-// Wraps an element of doc accessible via path in the dot notation
-// (http://docs.mongodb.org/manual/core/document/#document-dot-notation) in a
-// handler object that allows getting or setting the value of the element.  For
-// example, wrapElementForAccess({a: {b: 1}}, 'a.b').getValue() will return 1.
-// When getting a value, if leaf or intermediate children do not exist, the
-// result will be undefined. For example, wrapElementForAccess({a}, 'b') will
-// return undefined.  When setting a value which parent does not exists, the
-// parent will be created. For example, after running this code:
-//   var doc = {a: 1};
-//   wrapElementForAccess(doc, 'b.c').setValue(5);
-// doc will be {a: 1, b: {c: 5}}.
-//
-function wrapElementForAccess(doc, path) {
-  function newDocTraversalError(selector) {
-    return new InputDataError(util.format(
-      'cannot use the part (%s of %s) to traverse the element (%s)',
-      selector, path, util.format(doc)));
-  };
-  var wrapElement = function(parentElem, selector) {
-    var doc = parentElem.getValue();
-
-    return {
-      getValue: function() {
-        return _.isUndefined(doc) ? doc : doc[selector];
-      },
-      setValue: function(value) {
-        if (_.isArray(doc)) {
-          if (selector.match(/^[0-9]$/)) {
-            selector = parseInt(selector);
-            while (doc.length <= selector) {
-              doc.push(null);
-            }
-          } else {
-            throw newDocTraversalError(selector);
-          }
-        } else if (isAtomic(doc) && !_.isUndefined(doc)) {
-          throw newDocTraversalError(selector);
-        }
-        if (_.isUndefined(doc)) {
-          doc = {};
-          parentElem.setValue(doc);
-        }
-        doc[selector] = value;
-      },
-      deleteValue: function() {
-        if (_.isArray(doc) && selector.match(/^[0-9]$/)) {
-          var index = parseInt(selector);
-          if (index < doc.length) {
-            doc[index] = null;
-          }
-        } else if (_.isPlainObject(doc)) {
-          delete doc[selector];
-        }
-      }
-    };
-  }
-
-  var wrapElementAtPath = function(parentElem, selectors) {
-    if (selectors.length === 0) {
-      return parentElem;
-    }
-    var currentElem = wrapElement(parentElem, selectors[0]);
-    if (currentElem.error) {
-      return currentElem;
-    }
-    return wrapElementAtPath(currentElem, selectors.slice(1));
-  };
-
-  return wrapElementAtPath({getValue: function() { return doc; }}, path.split('.'));
-}
-
-function arrayPull(arr, value) {
-  var valuesEqual = function(a, b) {
-    if (a instanceof ObjectID) {
-      return a.equals(b);
-    } else if (b instanceof ObjectID) {
-      return b.equals(a);
-    }
-    return _.isEqual(a, b);
-  }
-  var i = 0;
-  while (i < arr.length) {
-    if (valuesEqual(value, arr[i])) {
-      arr.splice(i, 1);
-    } else {
-      ++i;
-    }
-  }
-}
-
 that = {
   mocks: null,
-  init: function (mocks) {
+  init: function(mocks) {
     logger = require('../lib/log').getLogger();
     that.mocks = mocks;
     filter.init();
@@ -338,10 +195,10 @@ that = {
     that.affectedDocuments = 0;
     var updateContainsOperators = _.any(
       clientReqMsg.update,
-      function(value, key) { return isOperator(key); });
+      function(value, key) { return helper.isOperator(key); });
     var updateContainsOnlyOperators = _.every(
       clientReqMsg.update,
-      function(value, key) { return isOperator(key); });
+      function(value, key) { return helper.isOperator(key); });
 
     if (clientReqMsg.flags.multiUpdate && !updateContainsOnlyOperators) {
       that.lastError = 'multi update only works with $ operators';
@@ -351,7 +208,7 @@ that = {
     var literalSubfield = _.findKey(
       clientReqMsg.update,
       function(value, key) {
-        return !isOperator(key) && _.contains(key, '.');
+        return !helper.isOperator(key) && _.contains(key, '.');
       });
     if (literalSubfield) {
       that.lastError = util.format(
@@ -362,97 +219,11 @@ that = {
     var upsertedDoc;
     if (docs.length === 0 && clientReqMsg.flags.upsert) {
       upsertedDoc = {};
-      if (updateContainsOperators) {
-        copyEqualityValues(upsertedDoc, clientReqMsg.selector);
-      }
       collection.push(upsertedDoc);
       docs = [upsertedDoc];
       // Now allow the update loop to update the newly inserted element.
     }
-    try {
-      _.forEach(docs, function (doc, index) {
-        if (!clientReqMsg.flags.multiUpdate && index > 0) {
-          // multi is off and we have already updated one document.
-          return false;  // Exit the loop.
-        }
-        that.affectedDocuments++;
-        var value;
-        // The document contains no operators, so its contents must be replaced
-        // entirely (see
-        // http://docs.mongodb.org/manual/reference/method/db.collection.update/#replace-a-document-entirely).
-        // Remove here fields that have no corresponding fields in the update
-        // document.
-        if (!updateContainsOperators) {
-          _.forOwn(doc, function(value, key) {
-            if (key !== '_id' && !(key in clientReqMsg.update)) {
-              delete doc[key];
-            }
-          });
-        }
-        for (updateKey in clientReqMsg.update) {
-          if (updateKey === '$setOnInsert' && !upsertedDoc) {
-            continue;
-          }
-          if (updateKey === '$set' ||
-              updateKey === '$unset' ||
-              updateKey === '$setOnInsert' ||
-              updateKey === '$inc' ||
-              updateKey === '$pull') {
-            for (propKey in clientReqMsg.update[updateKey]) {
-              var property = wrapElementForAccess(doc, propKey);
-              value = clientReqMsg.update[updateKey][propKey];
-              if (updateKey == '$inc') {
-                property.setValue(property.getValue() + value);
-              } else if (updateKey === '$unset') {
-                property.deleteValue();
-              } else if (updateKey === '$pull') {
-                // TODO(vladlosev): Support queries in $pull,
-                // e.g. db.collection.update({name: 'joe'}, {$pull: {scores: {$lt : 50}}})
-                var arr = property.getValue();
-                if (_.isUndefined(arr)) continue;
-                if (!_.isArray(arr)) {
-                  throw new InputDataError(
-                    'Cannot apply $pull to a non-array value');
-                }
-                arrayPull(arr, value);
-              } else {
-                property.setValue(value);
-              }
-            }
-          } else if (updateKey === '$pushAll') {
-            for (propKey in clientReqMsg.update[updateKey]) {
-              var property = wrapElementForAccess(doc, propKey);
-              var arr = property.getValue();
-              if (_.isUndefined(arr)) {
-                arr = [];
-                property.setValue(arr);
-              } else if (_.isArray(arr)) {
-                var values = clientReqMsg.update[updateKey][propKey];
-                values.forEach(function(element) { arr.push(element); });
-              } else {
-                throw new InputDataError(
-                  "The field '" + propKey + "' must be an array.");
-              }
-            }
-          } else if (isOperator(updateKey)) {
-            throw new Error('update value "' + updateKey + '" not supported');
-          } else {
-            // Literal value to set.
-            var property = wrapElementForAccess(doc, updateKey);
-            property.setValue(clientReqMsg.update[updateKey]);
-          }
-        }
-      });
-      if (upsertedDoc && !('_id' in upsertedDoc)) {
-        upsertedDoc._id = new ObjectID();
-      }
-    } catch (error) {
-      if (error instanceof InputDataError) {
-        that.lastError = error.message;
-      } else {
-        throw e;
-      }
-    }
+    update(docs, clientReqMsg, upsertedDoc, that);
   }
 };
 

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,0 +1,238 @@
+var _ = require('lodash');
+var util = require('util')
+var ObjectID = require('bson').ObjectID;
+
+var helper = require('./helper');
+
+function InputDataError(message) {
+  this.message = message;
+}
+InputDataError.prototype = new Error();
+
+// Determines whethe value is an atomic value (i.e., not an object or an
+// array).
+function isAtomic(value) {
+  if (typeof value === 'number') {
+    return true;
+  } else if (typeof value === 'string') {
+    return true;
+  } else if (value instanceof Date) {
+    return true;
+  } else if (value instanceof ObjectID) {
+    return true;
+  } else if (value === null) {
+    return true;
+  }
+  return false;
+}
+
+// Wraps an element of doc accessible via path in the dot notation
+// (http://docs.mongodb.org/manual/core/document/#document-dot-notation) in a
+// handler object that allows getting or setting the value of the element.  For
+// example, wrapElementForAccess({a: {b: 1}}, 'a.b').getValue() will return 1.
+// When getting a value, if leaf or intermediate children do not exist, the
+// result will be undefined. For example, wrapElementForAccess({a}, 'b') will
+// return undefined.  When setting a value which parent does not exists, the
+// parent will be created. For example, after running this code:
+//   var doc = {a: 1};
+//   wrapElementForAccess(doc, 'b.c').setValue(5);
+// doc will be {a: 1, b: {c: 5}}.
+//
+function wrapElementForAccess(doc, path) {
+  function newDocTraversalError(selector) {
+    return new InputDataError(util.format(
+      'cannot use the part (%s of %s) to traverse the element (%s)',
+      selector, path, util.format(doc)));
+  };
+  var wrapElement = function(parentElem, selector) {
+    var doc = parentElem.getValue();
+
+    return {
+      getValue: function() {
+        return _.isUndefined(doc) ? doc : doc[selector];
+      },
+      setValue: function(value) {
+        if (_.isArray(doc)) {
+          if (selector.match(/^[0-9]$/)) {
+            selector = parseInt(selector);
+            while (doc.length <= selector) {
+              doc.push(null);
+            }
+          } else {
+            throw newDocTraversalError(selector);
+          }
+        } else if (isAtomic(doc) && !_.isUndefined(doc)) {
+          throw newDocTraversalError(selector);
+        }
+        if (_.isUndefined(doc)) {
+          doc = {};
+          parentElem.setValue(doc);
+        }
+        doc[selector] = value;
+      },
+      deleteValue: function() {
+        if (_.isArray(doc) && selector.match(/^[0-9]$/)) {
+          var index = parseInt(selector);
+          if (index < doc.length) {
+            doc[index] = null;
+          }
+        } else if (_.isPlainObject(doc)) {
+          delete doc[selector];
+        }
+      }
+    };
+  }
+
+  var wrapElementAtPath = function(parentElem, selectors) {
+    if (selectors.length === 0) {
+      return parentElem;
+    }
+    var currentElem = wrapElement(parentElem, selectors[0]);
+    if (currentElem.error) {
+      return currentElem;
+    }
+    return wrapElementAtPath(currentElem, selectors.slice(1));
+  };
+
+  return wrapElementAtPath({getValue: function() { return doc; }}, path.split('.'));
+}
+
+// Assuming source is a MongoDB selector document, retrieves values from
+// equality comparisons (e,g, {a: 1}) and set them in destination.  If source
+// contains the $and operator, recurses over its arguments. E.g.,
+//   var doc = {};
+//   copyEqualityValues(doc, {a: 1, $and: [{b: 2}, {$and: [c: 5, 'd.e': 6]}]});
+// will make doc equal {a: 1, b: 2, c: 5, d: {e: 6}}.
+//
+function copyEqualityValues(destination, source) {
+  _.forOwn(source, function(value, key) {
+    if (!helper.isOperator(key)) {
+      if (isAtomic(value)) {
+        if (!helper.isOperator(value)) {
+          wrapElementForAccess(destination, key).setValue(value);
+        }
+      } else {
+        copyEqualityValues(destination, value);
+      }
+    } else if (key === '$and') {
+      _.forEach(value, function(elem) {
+        copyEqualityValues(destination, elem);
+      });
+    }
+  });
+}
+
+function arrayPull(arr, value) {
+  var valuesEqual = function(a, b) {
+    if (a instanceof ObjectID) {
+      return a.equals(b);
+    } else if (b instanceof ObjectID) {
+      return b.equals(a);
+    }
+    return _.isEqual(a, b);
+  }
+  var i = 0;
+  while (i < arr.length) {
+    if (valuesEqual(value, arr[i])) {
+      arr.splice(i, 1);
+    } else {
+      ++i;
+    }
+  }
+}
+
+function update(docs, clientReqMsg, upsertedDoc, context) {
+  var updateContainsOperators = _.any(
+    clientReqMsg.update,
+    function(value, key) { return helper.isOperator(key); });
+
+  if (upsertedDoc && updateContainsOperators) {
+    copyEqualityValues(upsertedDoc, clientReqMsg.selector);
+  }
+  try {
+    _.forEach(docs, function (doc, index) {
+      if (!clientReqMsg.flags.multiUpdate && index > 0) {
+        // multi is off and we have already updated one document.
+        return false;  // Exit the loop.
+      }
+      context.affectedDocuments++;
+      var value;
+      // The document contains no operators, so its contents must be replaced
+      // entirely (see
+      // http://docs.mongodb.org/manual/reference/method/db.collection.update/#replace-a-document-entirely).
+      // Remove here fields that have no corresponding fields in the update
+      // document.
+      if (!updateContainsOperators) {
+        _.forOwn(doc, function(value, key) {
+          if (key !== '_id' && !(key in clientReqMsg.update)) {
+            delete doc[key];
+          }
+        });
+      }
+      for (updateKey in clientReqMsg.update) {
+        if (updateKey === '$setOnInsert' && !upsertedDoc) {
+          continue;
+        }
+        if (updateKey === '$set' ||
+            updateKey === '$unset' ||
+            updateKey === '$setOnInsert' ||
+            updateKey === '$inc' ||
+            updateKey === '$pull') {
+          for (propKey in clientReqMsg.update[updateKey]) {
+            var property = wrapElementForAccess(doc, propKey);
+            value = clientReqMsg.update[updateKey][propKey];
+            if (updateKey == '$inc') {
+              property.setValue(property.getValue() + value);
+            } else if (updateKey === '$unset') {
+              property.deleteValue();
+            } else if (updateKey === '$pull') {
+              // TODO(vladlosev): Support queries in $pull,
+              // e.g. db.collection.update({name: 'joe'}, {$pull: {scores: {$lt : 50}}})
+              var arr = property.getValue();
+              if (_.isUndefined(arr)) continue;
+              if (!_.isArray(arr)) {
+                throw new InputDataError(
+                  'Cannot apply $pull to a non-array value');
+              }
+              arrayPull(arr, value);
+            } else {
+              property.setValue(value);
+            }
+          }
+        } else if (updateKey === '$pushAll') {
+          for (propKey in clientReqMsg.update[updateKey]) {
+            var property = wrapElementForAccess(doc, propKey);
+            var arr = property.getValue();
+            if (_.isUndefined(arr)) {
+              arr = [];
+              property.setValue(arr);
+            } else if (_.isArray(arr)) {
+              var values = clientReqMsg.update[updateKey][propKey];
+              values.forEach(function(element) { arr.push(element); });
+            } else {
+              throw new InputDataError(
+                "The field '" + propKey + "' must be an array.");
+            }
+          }
+        } else if (helper.isOperator(updateKey)) {
+          throw new Error('update value "' + updateKey + '" not supported');
+        } else {
+          // Literal value to set.
+          var property = wrapElementForAccess(doc, updateKey);
+          property.setValue(clientReqMsg.update[updateKey]);
+        }
+      }
+    });
+    if (upsertedDoc && !('_id' in upsertedDoc)) {
+      upsertedDoc._id = new ObjectID();
+    }
+  } catch (error) {
+    if (error instanceof InputDataError) {
+      context.lastError = error.message;
+    } else {
+      throw error;
+    }
+  }
+}
+
+module.exports = update;


### PR DESCRIPTION
@corydobson @parkr
I have plans to implement the  [findAndModify](http://docs.mongodb.org/manual/reference/method/db.collection.findAndModify/) command. `findAndModify` will share the update code with `update`, so it needs to be factored into a separate method. To keep `processor.js` simple, I think the update code also merits to be in a separate module.
