### PR TITLE
Bugfixes in $pushAll

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -201,14 +201,28 @@ function update(docs, clientReqMsg, upsertedDoc, context) {
           }
         } else if (updateKey === '$pushAll') {
           for (propKey in clientReqMsg.update[updateKey]) {
+            var values = clientReqMsg.update[updateKey][propKey];
+            if (!_.isArray(values)) {
+              var valuesTypeName;
+              switch (typeof values) {
+                case 'string':
+                  valuesTypeName = 'String';
+                  break;
+                case 'number':
+                  valuesTypeName = 'NumberDouble';
+                  break;
+                default:
+                  valuesTypeName = 'embedded document';
+              }
+              throw new InputDataError(
+                "$pushAll requires an array of values but was given an " + values);
+            }
             var property = wrapElementForAccess(doc, propKey);
             var arr = property.getValue();
             if (_.isUndefined(arr)) {
-              arr = [];
-              property.setValue(arr);
+              property.setValue(values);
             } else if (_.isArray(arr)) {
-              var values = clientReqMsg.update[updateKey][propKey];
-              values.forEach(function(element) { arr.push(element); });
+              property.setValue(arr.concat(values));
             } else {
               throw new InputDataError(
                 "The field '" + propKey + "' must be an array.");


### PR DESCRIPTION
@corydobson @parkr
This fixes two bugs in `$pushAll` operator for `update`:
1. Invalid handling on non-existent target fields. For example, running `db.collection.update({}, {$pushAll: {a: [1]}})` on a document `{b: 2}` would produce `{a: [], b: 2}` instead of `{a:[1], b: 2}`.
2. Not failing on non-array arguments properly. E.g., running `db.collection.update({}, {$pushAll: {a: 1}})` would cause unhandled exception instead of returning the same error message as MongoDB.
