### PR TITLE
Implements findAndModify

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -59,6 +59,15 @@ that = {
     }
     return true;
   },
+
+  cloneDocuments: function cloneDocuments(doc) {
+    return _.cloneDeep(
+      doc,
+      function(value) {
+        return value instanceof ObjectID ? new ObjectID(value) : undefined;
+      });
+  },
+
   clone: function (src) {
     return JSON.parse(JSON.stringify(src));
   },

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,10 +1,10 @@
 var _ = require('lodash');
 var util = require('util');
 var net = require('net');
-var ObjectID = require('bson').ObjectID;
 
 var helper = require('./helper');
 var filter = require('./filter');
+var projection = require('./projection');
 var update = require('./update');
 
 var logger;
@@ -15,14 +15,6 @@ function getCollection(clientReqMsg) {
 
 function keyIsOperator(value, key) {
   return helper.isOperator(key);
-}
-
-function cloneDocuments(doc) {
-  return _.cloneDeep(
-    doc,
-    function(value) {
-      return value instanceof ObjectID ? new ObjectID(value) : undefined;
-    });
 }
 
 that = {
@@ -299,9 +291,15 @@ that = {
           literalSubfield));
       return;
     }
+    var projectionError = projection.validateProjection(
+      clientReqMsg.query.fields);
+    if (projectionError) {
+      writeErrorReply(clientReqMsg, projectionError.message);
+      return;
+    }
     var returnedDoc = null;
     if (!clientReqMsg.query.new) {
-      returnedDoc = cloneDocuments(docs[0]);
+      returnedDoc = helper.cloneDocuments(docs[0]);
     }
     var upsertedDoc;
     if (clientReqMsg.query.update) {
@@ -342,6 +340,9 @@ that = {
     if (clientReqMsg.query.new) {
       returnedDoc = docs.length > 0 ? docs[0] : null;
     }
+    returnedDoc = projection.getProjection(
+      [returnedDoc],
+      clientReqMsg.query.fields)[0];
     var reply = {documents: {value: returnedDoc}};
     var replyBuf = helper.toOpReplyBuf(clientReqMsg, reply);
     socket.write(replyBuf);

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,13 +1,28 @@
 var _ = require('lodash');
-var util = require('util')
-  , net = require('net')
-  , helper = require('./helper')
-  , filter = require('./filter')
-  , logger;
+var util = require('util');
+var net = require('net');
+var ObjectID = require('bson').ObjectID;
+
+var helper = require('./helper');
+var filter = require('./filter');
 var update = require('./update');
 
+var logger;
+
 function getCollection(clientReqMsg) {
-  return eval('that.mocks.' + clientReqMsg.fullCollectionName);
+  return eval('that.mocks.' + clientReqMsg.fullCollectionName) || [];
+}
+
+function keyIsOperator(value, key) {
+  return helper.isOperator(key);
+}
+
+function cloneDocuments(doc) {
+  return _.cloneDeep(
+    doc,
+    function(value) {
+      return value instanceof ObjectID ? new ObjectID(value) : undefined;
+    });
 }
 
 that = {
@@ -26,7 +41,11 @@ that = {
         case helper.OP_QUERY:
           clientReqMsg = helper.fromOpQueryBuf(header, buf);
           if (clientReqMsg.fullCollectionName.match(/\.\$cmd$/)) {
-            that.doCmdQuery(socket, clientReqMsg);
+            if (clientReqMsg.query && clientReqMsg.query.findandmodify) {
+              that.doFindAndModify(socket, clientReqMsg);
+            } else {
+              that.doCmdQuery(socket, clientReqMsg);
+            }
           } else {
             that.doQuery(socket, clientReqMsg);
           }
@@ -184,21 +203,19 @@ that = {
     }
   },
   doUpdate: function (socket, clientReqMsg) {
-    var collection, docs, updateKey, propKey;
     logger.trace('doUpdate');
-    collection = getCollection(clientReqMsg);
+    var collection = getCollection(clientReqMsg);
+    var docs;
     if (clientReqMsg.selector && !helper.isEmpty(clientReqMsg.selector)) {
       docs = filter.filterItems(collection, clientReqMsg.selector);
     } else {
       docs = collection;
     }
     that.affectedDocuments = 0;
-    var updateContainsOperators = _.any(
-      clientReqMsg.update,
-      function(value, key) { return helper.isOperator(key); });
+    var updateContainsOperators = _.any(clientReqMsg.update, keyIsOperator);
     var updateContainsOnlyOperators = _.every(
       clientReqMsg.update,
-      function(value, key) { return helper.isOperator(key); });
+      keyIsOperator);
 
     if (clientReqMsg.flags.multiUpdate && !updateContainsOnlyOperators) {
       that.lastError = 'multi update only works with $ operators';
@@ -221,9 +238,113 @@ that = {
       upsertedDoc = {};
       collection.push(upsertedDoc);
       docs = [upsertedDoc];
-      // Now allow the update loop to update the newly inserted element.
     }
-    update(docs, clientReqMsg, upsertedDoc, that);
+    update(
+      docs,
+      clientReqMsg.selector,
+      clientReqMsg.update,
+      clientReqMsg.flags.multiUpdate,
+      upsertedDoc,
+      that);
+  },
+  doFindAndModify: function(socket, clientReqMsg) {
+    function writeErrorReply(clientReqMsg, errorMessage) {
+      var reply = {documents: [{ok: false, errmsg: errorMessage}]};
+      var replyBuf = helper.toOpReplyBuf(clientReqMsg, reply);
+      socket.write(replyBuf);
+    }
+
+    logger.trace('doFindAndModify');
+    var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
+    var collectionName = clientReqMsg.query.findandmodify;
+    var collection = that.mocks[dbName][collectionName] || [];
+    var docs;
+    if (clientReqMsg.query && !helper.isEmpty(clientReqMsg.query.query)) {
+      docs = filter.filterItems(collection, clientReqMsg.query.query);
+    } else {
+      docs = collection;
+    }
+    var updateKeys = Object.keys(clientReqMsg.query.update || {});
+    var firstOperatorIndex = _.findIndex(updateKeys,helper.isOperator);
+    var firstNonOperatorIndex = _.findIndex(updateKeys, function(key) {
+      return !helper.isOperator(key);
+    });
+    if (firstOperatorIndex >= 0 && firstNonOperatorIndex >= 0) {
+      var errorMessage;
+      if (firstOperatorIndex < firstNonOperatorIndex) {
+        errorMessage = util.format(
+          "exception: Unknown modifier: %s",
+          updateKeys[firstNonOperatorIndex]);
+      } else {
+        errorMessage = util.format(
+          "exception: The dollar ($) prefixed field '%s' " +
+          "in '%s' is not valid for storage.",
+          updateKeys[firstOperatorIndex],
+          updateKeys[firstOperatorIndex]);
+      }
+      writeErrorReply(clientReqMsg, errorMessage);
+      return;
+    }
+    var literalSubfield = _.findKey(
+      clientReqMsg.query.update,
+      function(value, key) {
+        return !helper.isOperator(key) && _.contains(key, '.');
+      });
+    if (literalSubfield) {
+      writeErrorReply(
+        clientReqMsg,
+        util.format(
+          "exception: The dotted field '%s' in '%s' is not valid for storage.",
+          literalSubfield,
+          literalSubfield));
+      return;
+    }
+    var returnedDoc = null;
+    if (!clientReqMsg.query.new) {
+      returnedDoc = cloneDocuments(docs[0]);
+    }
+    var upsertedDoc;
+    if (clientReqMsg.query.update) {
+      if (docs.length === 0 && clientReqMsg.query.upsert) {
+        upsertedDoc = {};
+        docs = [upsertedDoc];
+      }
+      update(
+        docs,
+        clientReqMsg.query.query,
+        clientReqMsg.query.update,
+        false,
+        upsertedDoc,
+        that);
+    } else if (clientReqMsg.query.remove) {
+      if (clientReqMsg.query.new) {
+        writeErrorReply(clientReqMsg, "remove and returnNew can't co-exist");
+        return;
+      }
+      if (docs.length > 0) {
+        _.pull(collection, docs[0]);
+      }
+    } else {
+      that.lastError = 'need remove or update';
+    }
+    if (that.lastError) {
+      writeErrorReply(clientReqMsg, that.lastError);
+      delete that.lastError;
+      return;
+    }
+    if (upsertedDoc) {
+      if (!that.mocks[dbName][collectionName]) {
+        that.mocks[dbName][collectionName] = docs;
+      } else {
+        collection.push(upsertedDoc);
+      }
+    }
+    if (clientReqMsg.query.new) {
+      returnedDoc = docs.length > 0 ? docs[0] : null;
+    }
+    var reply = {documents: {value: returnedDoc}};
+    var replyBuf = helper.toOpReplyBuf(clientReqMsg, reply);
+    socket.write(replyBuf);
   }
 };
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -291,10 +291,11 @@ that = {
           literalSubfield));
       return;
     }
-    var projectionError = projection.validateProjection(
-      clientReqMsg.query.fields);
-    if (projectionError) {
-      writeErrorReply(clientReqMsg, projectionError.message);
+    if (!projection.validateProjection(clientReqMsg.query.fields)) {
+      writeErrorReply(
+        clientReqMsg,
+        'exception: You cannot currently mix including and excluding fields. ' +
+        'Contact us if this is an issue.');
       return;
     }
     var returnedDoc = null;

--- a/lib/projection.js
+++ b/lib/projection.js
@@ -36,22 +36,19 @@ function excludeField(doc, fieldSelector) {
 // Validates projectionDoc as a projection document. Returns an Error if
 // projectionDoc is invalid or a falsy value if it's valid.
 function validateProjection(projectionDoc) {
+  if (!projectionDoc) {
+    return true;
+  }
   var includeFields = Object.keys(_.pick(projectionDoc, function(elem) {
     return elem;
   }));
   var excludeFields = Object.keys(_.pick(projectionDoc, function(elem) {
     return !elem;
   }));
-  var result;
 
-  if (includeFields.length > 0) {
-    if (excludeFields.length > 1 ||
-        (excludeFields.length === 1 && excludeFields[0] !== '_id')) {
-      return new Error(
-        'BadValue Projection cannot have a mix of inclusion and exclusion.');
-    }
-  }
-  return null;
+  return includeFields.length === 0 ||
+         excludeFields.length === 0 ||
+         (excludeFields.length === 1 && excludeFields[0] === '_id');
 }
 
 // Returns projections of docuements in docs described by projectionDoc.

--- a/lib/projection.js
+++ b/lib/projection.js
@@ -1,0 +1,101 @@
+var _ = require('lodash');
+var ObjectID = require('bson').ObjectID;
+
+var helper = require('./helper');
+
+function selectField(doc, fieldSelector) {
+  if (fieldSelector.length > 0) {
+    var key = fieldSelector[0];
+    if (key in doc) {
+      var value = selectField(doc[key], fieldSelector.slice(1));
+      if (value !== undefined) {
+        var result = {};
+        result[key] = value;
+        return result;
+      }
+    }
+    return undefined;
+  } else {
+    return doc;
+  }
+}
+
+function excludeField(doc, fieldSelector) {
+  if (fieldSelector.length > 0) {
+    var key = fieldSelector[0];
+    if (key in doc) {
+      if (fieldSelector.length === 1) {
+        delete doc[key];
+      } else {
+        excludeField(doc[key], fieldSelector.slice(1));
+      }
+    }
+  }
+}
+
+// Validates projectionDoc as a projection document. Returns an Error if
+// projectionDoc is invalid or a falsy value if it's valid.
+function validateProjection(projectionDoc) {
+  var includeFields = Object.keys(_.pick(projectionDoc, function(elem) {
+    return elem;
+  }));
+  var excludeFields = Object.keys(_.pick(projectionDoc, function(elem) {
+    return !elem;
+  }));
+  var result;
+
+  if (includeFields.length > 0) {
+    if (excludeFields.length > 1 ||
+        (excludeFields.length === 1 && excludeFields[0] !== '_id')) {
+      return new Error(
+        'BadValue Projection cannot have a mix of inclusion and exclusion.');
+    }
+  }
+  return null;
+}
+
+// Returns projections of docuements in docs described by projectionDoc.
+// This method assumes projectionDoc has been validated by validateProjection.
+// Its behavior is undefined unless validation has been performed.
+function getProjection(docs, projectionDoc) {
+  if (!projectionDoc || Object.keys(projectionDoc).length === 0) {
+    return docs;
+  }
+  var includeFields = Object.keys(_.pick(projectionDoc, function(elem) {
+    return elem;
+  }));
+  var excludeFields = Object.keys(_.pick(projectionDoc, function(elem) {
+    return !elem;
+  }));
+  var result;
+
+  if (includeFields.length > 0) {
+    result = _.map(docs, function(doc) {
+      var resultDoc = {};
+      if (excludeFields.length === 0) {
+        resultDoc._id = doc._id;
+      }
+      _.forEach(includeFields, function(selector) {
+        var selectedPart = selectField(doc, selector.split('.'));
+        if (selectedPart !== undefined) {
+          _.merge(resultDoc, selectedPart);
+        }
+      });
+      return resultDoc;
+    });
+  } else {
+    result = _.map(docs, function(doc) {
+      var resultDoc = helper.cloneDocuments(doc);
+      _.forEach(excludeFields, function(selector) {
+        excludeField(resultDoc, selector.split('.'));
+      });
+      return resultDoc;
+    });
+  }
+  return result;
+}
+
+module.exports = {
+  validateProjection: validateProjection,
+  getProjection: getProjection
+};

--- a/lib/update.js
+++ b/lib/update.js
@@ -141,17 +141,17 @@ function arrayPull(arr, value) {
   }
 }
 
-function update(docs, clientReqMsg, upsertedDoc, context) {
+function update(docs, query, updateDoc, multiUpdate, upsertedDoc, context) {
   var updateContainsOperators = _.any(
-    clientReqMsg.update,
+    updateDoc,
     function(value, key) { return helper.isOperator(key); });
 
   if (upsertedDoc && updateContainsOperators) {
-    copyEqualityValues(upsertedDoc, clientReqMsg.selector);
+    copyEqualityValues(upsertedDoc, query);
   }
   try {
     _.forEach(docs, function (doc, index) {
-      if (!clientReqMsg.flags.multiUpdate && index > 0) {
+      if (!multiUpdate && index > 0) {
         // multi is off and we have already updated one document.
         return false;  // Exit the loop.
       }
@@ -164,12 +164,12 @@ function update(docs, clientReqMsg, upsertedDoc, context) {
       // document.
       if (!updateContainsOperators) {
         _.forOwn(doc, function(value, key) {
-          if (key !== '_id' && !(key in clientReqMsg.update)) {
+          if (key !== '_id' && !(key in updateDoc)) {
             delete doc[key];
           }
         });
       }
-      for (updateKey in clientReqMsg.update) {
+      for (updateKey in updateDoc) {
         if (updateKey === '$setOnInsert' && !upsertedDoc) {
           continue;
         }
@@ -178,9 +178,9 @@ function update(docs, clientReqMsg, upsertedDoc, context) {
             updateKey === '$setOnInsert' ||
             updateKey === '$inc' ||
             updateKey === '$pull') {
-          for (propKey in clientReqMsg.update[updateKey]) {
+          for (propKey in updateDoc[updateKey]) {
             var property = wrapElementForAccess(doc, propKey);
-            value = clientReqMsg.update[updateKey][propKey];
+            value = updateDoc[updateKey][propKey];
             if (updateKey == '$inc') {
               property.setValue(property.getValue() + value);
             } else if (updateKey === '$unset') {
@@ -200,8 +200,8 @@ function update(docs, clientReqMsg, upsertedDoc, context) {
             }
           }
         } else if (updateKey === '$pushAll') {
-          for (propKey in clientReqMsg.update[updateKey]) {
-            var values = clientReqMsg.update[updateKey][propKey];
+          for (propKey in updateDoc[updateKey]) {
+            var values = updateDoc[updateKey][propKey];
             if (!_.isArray(values)) {
               var valuesTypeName;
               switch (typeof values) {
@@ -233,7 +233,7 @@ function update(docs, clientReqMsg, upsertedDoc, context) {
         } else {
           // Literal value to set.
           var property = wrapElementForAccess(doc, updateKey);
-          property.setValue(clientReqMsg.update[updateKey]);
+          property.setValue(updateDoc[updateKey]);
         }
       }
     });

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   "devDependencies": {
     "mocha": "~1.21.4",
     "mongoose": "~3.8.18",
-    "chai": "~1.9.1"
+    "chai": "~1.10.0"
   }
 }

--- a/test/testInProcess.js
+++ b/test/testInProcess.js
@@ -870,7 +870,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       });
     });
 
-    xit('returns requested projection of original document', function(done) {
+    it('returns requested projection of original document', function(done) {
       FreeItem.collection.findAndModify(
         {b: 1},
         null,
@@ -896,7 +896,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       });
     });
 
-    xit('returns requested projection of updated document when new is set',
+    it('returns requested projection of updated document when new is set',
       function(done) {
         FreeItem.collection.findAndModify(
           {b: 1},
@@ -908,6 +908,28 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
             expect(item).to.deep.equal({a: 'new value', _id: id1});
             done();
         });
+    });
+
+    it('rejects invalid requested projections', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 1},
+        null,
+        {'$set': {a: 'new value'}},
+        {fields: {a: 1, b: 0}},
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('name', 'MongoError');
+          expect(error)
+            .to.have.property('message')
+            .to.have.string(
+              'BadValue Projection cannot have a mix ' +
+              'of inclusion and exclusion.');
+
+          // The collection must remain unchanged.
+          expect(config.mocks.fakedb.freeitems)
+            .to.deep.equal(originalFreeItems);
+          done();
+      });
     });
 
     it('returns null when document is not found', function(done) {
@@ -930,7 +952,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
           expect(error).to.have.property('name', 'MongoError');
           expect(error)
             .to.have.property('message')
-            .to.have.string("need remove or update");
+            .to.have.string('need remove or update');
 
           // The collection must remain unchanged.
           expect(config.mocks.fakedb.freeitems)
@@ -970,7 +992,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
           expect(error).to.have.property('name', 'MongoError');
           expect(error)
             .to.have.property('message')
-            .to.have.string("exception: Unknown modifier: a");
+            .to.have.string('exception: Unknown modifier: a');
 
           // The collection must remain unchanged.
           expect(config.mocks.fakedb.freeitems)
@@ -1148,7 +1170,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
         });
       });
 
-      xit('returns requested projection of new document upserting and new set',
+      it('returns requested projection of new document with new set',
         function(done) {
           FreeItem.collection.findAndModify(
             {b: 3},

--- a/test/testInProcess.js
+++ b/test/testInProcess.js
@@ -826,6 +826,346 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     });
   });
 
+  describe('findAndModify', function() {
+    var id1 = new mongoose.Types.ObjectId();
+    var id2 = new mongoose.Types.ObjectId();
+    var originalFreeItems = [
+      {a: 'value', b: 1, _id: id1},
+      {a: 'value', b: 2, _id: id2}];
+
+    beforeEach(function() {
+      config.mocks.fakedb.freeitems = _.cloneDeep(
+        originalFreeItems,
+        function(value) {
+          return value instanceof mongoose.Types.ObjectId ?
+            new mongoose.Types.ObjectId(value) :
+            undefined;
+        });
+    });
+
+    it('finds and updates a document', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 1},
+        {},
+        {'$set': {a: 'new value'}},
+        function(error) {
+          if (error) return done(error);
+          expect(config.mocks.fakedb.freeitems)
+            .to.deep.equal([
+              {a: 'new value', b: 1, _id: id1},  // Has new value.
+              originalFreeItems[1]]);
+          done();
+      });
+    });
+
+    it('returns original document', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 1},
+        {},
+        {'$set': {a: 'new value'}},
+        function(error, item) {
+          if (error) return done(error);
+          expect(item).to.deep.equal(originalFreeItems[0]);
+          done();
+      });
+    });
+
+    xit('returns requested projection of original document', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 1},
+        null,
+        {'$set': {a: 'new value'}},
+        {fields: {a: 1}},
+        function(error, item) {
+          if (error) return done(error);
+          expect(item).to.deep.equal({a: 'value', _id: id1});
+          done();
+      });
+    });
+
+    it('returns new document when new is set', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 1},
+        {},
+        {'$set': {a: 'new value'}},
+        {'new': true},
+        function(error, item) {
+          if (error) return done(error);
+          expect(item).to.deep.equal({a: 'new value', b: 1, _id: id1});
+          done();
+      });
+    });
+
+    xit('returns requested projection of updated document when new is set',
+      function(done) {
+        FreeItem.collection.findAndModify(
+          {b: 1},
+          null,
+          {'$set': {a: 'new value'}},
+          {fields: {a: 1}, 'new': 1},
+          function(error, item) {
+            if (error) return done(error);
+            expect(item).to.deep.equal({a: 'new value', _id: id1});
+            done();
+        });
+    });
+
+    it('returns null when document is not found', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 'non-existent'},
+        {},
+        {'$set': {a: 'new value'}},
+        function(error, item) {
+          if (error) return done(error);
+          expect(item).to.equal(null);
+          done();
+      });
+    });
+
+    it('fails when update document is not specified', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 1},
+        function(error, item) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('name', 'MongoError');
+          expect(error)
+            .to.have.property('message')
+            .to.have.string("need remove or update");
+
+          // The collection must remain unchanged.
+          expect(config.mocks.fakedb.freeitems)
+            .to.deep.equal(originalFreeItems);
+          done();
+      });
+    });
+
+    it('fails when operators follow fields in update', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 1},
+        {},
+        {a: 'new value', $set: {b: 5}},
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('name', 'MongoError');
+          expect(error)
+            .to.have.property('message')
+            .to.have.string(
+              "exception: The dollar ($) prefixed field '$set' " +
+              "in '$set' is not valid for storage.");
+
+          // The collection must remain unchanged.
+          expect(config.mocks.fakedb.freeitems)
+            .to.deep.equal(originalFreeItems);
+          done();
+      });
+    });
+
+    it('fails when fields follow operators in update', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 1},
+        {},
+        {$set: {b: 5}, a: 'new value'},
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('name', 'MongoError');
+          expect(error)
+            .to.have.property('message')
+            .to.have.string("exception: Unknown modifier: a");
+
+          // The collection must remain unchanged.
+          expect(config.mocks.fakedb.freeitems)
+            .to.deep.equal(originalFreeItems);
+          done();
+      });
+    });
+
+    it('fails when direct field asignments use dot notation', function(done) {
+      FreeItem.collection.findAndModify(
+        {b: 1},
+        {},
+        {'y.z': 5},
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('name', 'MongoError');
+          expect(error)
+            .to.have.property('message')
+            .to.have.string(
+              "exception: The dotted field 'y.z' in 'y.z' " +
+              'is not valid for storage.');
+
+          // The collection must remain unchanged.
+          expect(config.mocks.fakedb.freeitems)
+            .to.deep.equal(originalFreeItems);
+          done();
+      });
+    });
+
+    xit('updates the first document in specified sort order', function(done) {
+      done();
+    });
+
+    xit('updates the first document in the default sort order', function(done) {
+      done();
+    });
+
+    describe('with remove option set', function() {
+      it('deletes the found document', function(done) {
+        FreeItem.collection.findAndModify(
+          {b: 1},
+          null,
+          null,
+          {remove: true},
+          function(error, item) {
+            if (error) return done(error);
+            // The first record is deleted.
+            expect(config.mocks.fakedb.freeitems)
+              .to.deep.equal(originalFreeItems.slice(1, 2));
+            done();
+        });
+      });
+
+      it('returns the deleted document', function(done) {
+        FreeItem.collection.findAndModify(
+          {b: 1},
+          null,
+          null,
+          {remove: true},
+          function(error, item) {
+            if (error) return done(error);
+            // The first record is deleted.
+            expect(config.mocks.fakedb.freeitems)
+              .to.deep.equal(originalFreeItems.slice(1, 2));
+            done();
+        });
+      });
+
+      it('ignores update document', function(done) {
+        FreeItem.collection.findAndModify(
+          {b: 1},
+          null,
+          {a: 'new value'},
+          {remove: true},
+          function(error) {
+            if (error) return done(error);
+
+            // The first record is deleted even though update is specified.
+            expect(config.mocks.fakedb.freeitems)
+              .to.deep.equal(originalFreeItems.slice(1, 2));
+            done();
+        });
+      });
+
+      it('fails when new is specified', function(done) {
+        FreeItem.collection.findAndModify(
+          {b: 1},
+          null,
+          null,
+          {remove: true, 'new': true},
+          function(error) {
+            expect(error).to.have.property('ok', false);
+            expect(error).to.have.property('name', 'MongoError');
+            expect(error)
+              .to.have.property('message')
+              .to.have.string("remove and returnNew can't co-exist");
+
+            // The collection must remain unchanged.
+            expect(config.mocks.fakedb.freeitems)
+              .to.deep.equal(originalFreeItems);
+            done();
+        });
+      });
+
+      xit('removes first document in specified sort order', function(done) {
+        done();
+      });
+
+      xit('removes first document in default sort order', function(done) {
+        done();
+      });
+    });
+
+    describe('with upsert options set', function() {
+      it('updates existing document', function(done) {
+        FreeItem.collection.findAndModify(
+          {b: 1},
+          null,
+          {'$set': {a: 'new value'}},
+          {upsert: true},
+          function(error) {
+            if (error) return done(error);
+            expect(config.mocks.fakedb.freeitems)
+              .to.deep.equal([
+                {a: 'new value', b: 1, _id: id1},  // Has new value.
+                originalFreeItems[1]]);
+            done();
+        });
+      });
+
+      it('inserts new document when no matches', function(done) {
+        FreeItem.collection.findAndModify(
+          {b: 3},
+          null,
+          {'$set': {a: 'new value'}},
+          {upsert: true},
+          function(error) {
+            if (error) return done(error);
+            expect(config.mocks.fakedb.freeitems).to.have.length(3);
+            expect(config.mocks.fakedb.freeitems.slice(0,2))
+              .to.deep.equal(originalFreeItems);
+            expect(config.mocks.fakedb.freeitems[2])
+              .to.have.deep.property('_id.constructor.name', 'ObjectID');
+            expect(_.omit(config.mocks.fakedb.freeitems[2], '_id'))
+              .to.deep.equal({b: 3, a: 'new value'});
+            done();
+        });
+      });
+
+      it('returns null when upserting', function(done) {
+        FreeItem.collection.findAndModify(
+          {b: 3},
+          null,
+          {'$set': {a: 'new value'}},
+          {upsert: true},
+          function(error, item) {
+            if (error) return done(error);
+            expect(item).to.equal(null);
+            done();
+        });
+      });
+
+      it('returns new document when upserting and new is set', function(done) {
+        FreeItem.collection.findAndModify(
+          {b: 3},
+          null,
+          {'$set': {a: 'new value'}},
+          {upsert: true, 'new': true},
+          function(error, item) {
+            if (error) return done(error);
+            expect(item)
+              .to.have.deep.property('_id.constructor.name', 'ObjectID');
+            expect(_.omit(item, '_id')).to.deep.equal({b: 3, a: 'new value'});
+            done();
+        });
+      });
+
+      xit('returns requested projection of new document upserting and new set',
+        function(done) {
+          FreeItem.collection.findAndModify(
+            {b: 3},
+            null,
+            {'$set': {a: 'new value'}},
+            {fields: {a: 1}, upsert: true, 'new': true},
+            function(error, item) {
+              if (error) return done(error);
+              expect(item)
+                .to.have.deep.property('_id.constructor.name', 'ObjectID');
+              expect(_.omit(item, '_id')).to.deep.equal({a: 'new value'});
+              done();
+          });
+      });
+    });
+  });
+
   describe('count', function() {
     it('returns the number of queried documents', function(done) {
       config.mocks.fakedb.numberitems = [{key: 1}, {key: 2}, {key: 3}];

--- a/test/testInProcess.js
+++ b/test/testInProcess.js
@@ -922,8 +922,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
           expect(error)
             .to.have.property('message')
             .to.have.string(
-              'BadValue Projection cannot have a mix ' +
-              'of inclusion and exclusion.');
+              'You cannot currently mix including and excluding fields');
 
           // The collection must remain unchanged.
           expect(config.mocks.fakedb.freeitems)

--- a/test/testProjection.js
+++ b/test/testProjection.js
@@ -13,26 +13,29 @@ describe('projection', function() {
   var id1Copy = new ObjectID(id1);
 
   describe('validateProjection', function() {
+    it('allows falsy value as projection', function() {
+      chai.expect(projection.validateProjection(null))
+        .to.be.ok();
+    });
+
     it('allows pure inclusion projection', function() {
       chai.expect(projection.validateProjection({x: 1, y: 1}))
-        .to.not.exist();
+        .to.be.ok();
     });
 
     it('allows inclusion projection with _id excluded', function() {
       chai.expect(projection.validateProjection({x: 1, _id: 0}))
-        .to.not.exist();
+        .to.be.ok();
     });
 
     it('allows pure inclusion projection', function() {
       chai.expect(projection.validateProjection({x: 0, y: 0}))
-        .to.not.exist();
+        .to.be.ok();
     });
 
     it('disallows mixed inclusion and exclusion', function() {
       chai.expect(projection.validateProjection({x: 1, y: 0}))
-        .to.have.property('message')
-        .to.have.string(
-          'BadValue Projection cannot have a mix of inclusion and exclusion.');
+        .to.be.not.ok();
     });
   });
 

--- a/test/testProjection.js
+++ b/test/testProjection.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var _ = require('lodash')
+var chai = require('chai')
+var ObjectID = require('bson').ObjectID;
+
+var projection = require('../lib/projection');
+
+describe('projection', function() {
+  var expect = chai.expect;
+
+  var id1 = new ObjectID();
+  var id1Copy = new ObjectID(id1);
+
+  describe('validateProjection', function() {
+    it('allows pure inclusion projection', function() {
+      chai.expect(projection.validateProjection({x: 1, y: 1}))
+        .to.not.exist();
+    });
+
+    it('allows inclusion projection with _id excluded', function() {
+      chai.expect(projection.validateProjection({x: 1, _id: 0}))
+        .to.not.exist();
+    });
+
+    it('allows pure inclusion projection', function() {
+      chai.expect(projection.validateProjection({x: 0, y: 0}))
+        .to.not.exist();
+    });
+
+    it('disallows mixed inclusion and exclusion', function() {
+      chai.expect(projection.validateProjection({x: 1, y: 0}))
+        .to.have.property('message')
+        .to.have.string(
+          'BadValue Projection cannot have a mix of inclusion and exclusion.');
+    });
+  });
+
+  describe('getProjection', function() {
+    var doc = {_id: id1, a: 1, b: {c: 'd', x: 'y'}};
+
+    it('returns full document for null', function() {
+      chai.expect(projection.getProjection([doc], null))
+        .to.deep.equal([doc]);
+    });
+
+    it('returns full document for empty projection doc', function() {
+      chai.expect(projection.getProjection([doc], {}))
+        .to.deep.equal([doc]);
+    });
+
+    it('selects fields with inclusion projection', function() {
+      chai.expect(projection.getProjection([doc], {a: 1}))
+        .to.deep.equal([{_id: id1, a: 1}]);
+    });
+
+    it('selects subfields with dot notation', function() {
+      chai.expect(projection.getProjection([doc], {'b.c': 1}))
+        .to.deep.equal([{_id: id1, b: {c: 'd'}}]);
+    });
+
+    it('allows _id exclusion in inclusion projection', function() {
+      chai.expect(projection.getProjection([doc], {a: 1, _id: 0}))
+        .to.deep.equal([{a: 1}]);
+    });
+
+    it('excludes fields with exclusion projection', function() {
+      chai.expect(projection.getProjection([doc], {b: 0}))
+        .to.deep.equal([{_id: id1, a: 1}]);
+    });
+
+    it('excludes fields with dot notation', function() {
+      chai.expect(projection.getProjection([doc], {'b.c': 0}))
+        .to.deep.equal([{_id: id1, a: 1, b: {x: 'y'}}]);
+    });
+
+    it('excluding non-existent fields does not affect projection', function() {
+      chai.expect(projection.getProjection([doc], {f: 0}))
+        .to.deep.equal([doc]);
+    });
+
+    it('exclusion can generate empty subdocuments', function() {
+      chai.expect(projection.getProjection([doc], {'b.c': 0, 'b.x': 0}))
+        .to.deep.equal([{_id: id1, a: 1, b: {}}]);
+    });
+  });
+});


### PR DESCRIPTION
@corydobson, @parkr, @MrNice: This change implements support for `findAndModify`. That handy method allows one to modify or remove a document and get back its contents, either old or new.