### PR TITLE
Implements the distinct method.

### DIFF
--- a/lib/element-wrapper.js
+++ b/lib/element-wrapper.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var _ = require('lodash');
+var util = require('util');
+
+var utils = require('./utils');
+
+// Wraps an element of doc accessible via path in the dot notation
+// (http://docs.mongodb.org/manual/core/document/#document-dot-notation) in a
+// handler object that allows getting or setting the value of the element.  For
+// example, wrapElementForAccess({a: {b: 1}}, 'a.b').getValue() will return 1.
+// When getting a value, if leaf or intermediate children do not exist, the
+// result will be undefined. For example, wrapElementForAccess({a}, 'b') will
+// return undefined.  When setting a value which parent does not exists, the
+// parent will be created. For example, after running this code:
+//   var doc = {a: 1};
+//   wrapElementForAccess(doc, 'b.c').setValue(5);
+// doc will be {a: 1, b: {c: 5}}.
+//
+function wrapElementForAccess(doc, path) {
+  function newDocTraversalError(selector) {
+    return new utils.InputDataError(util.format(
+      'cannot use the part (%s of %s) to traverse the element (%s)',
+      selector, path, util.format(doc)));
+  };
+  var wrapElement = function(parentElem, selector) {
+    var doc = parentElem.getValue();
+
+    return {
+      getValue: function() {
+        return _.isUndefined(doc) ? doc : doc[selector];
+      },
+      setValue: function(value) {
+        if (_.isArray(doc)) {
+          if (selector.match(/^[0-9]$/)) {
+            selector = parseInt(selector);
+            while (doc.length <= selector) {
+              doc.push(null);
+            }
+          } else {
+            throw newDocTraversalError(selector);
+          }
+        } else if (utils.isAtomic(doc) && !_.isUndefined(doc)) {
+          throw newDocTraversalError(selector);
+        }
+        if (_.isUndefined(doc)) {
+          doc = {};
+          parentElem.setValue(doc);
+        }
+        doc[selector] = value;
+      },
+      deleteValue: function() {
+        if (_.isArray(doc) && selector.match(/^[0-9]$/)) {
+          var index = parseInt(selector);
+          if (index < doc.length) {
+            doc[index] = null;
+          }
+        } else if (_.isPlainObject(doc)) {
+          delete doc[selector];
+        }
+      }
+    };
+  }
+
+  var wrapElementAtPath = function(parentElem, selectors) {
+    if (selectors.length === 0) {
+      return parentElem;
+    }
+    var currentElem = wrapElement(parentElem, selectors[0]);
+    if (currentElem.error) {
+      return currentElem;
+    }
+    return wrapElementAtPath(currentElem, selectors.slice(1));
+  };
+
+  return wrapElementAtPath({getValue: function() { return doc; }}, path.split('.'));
+}
+
+module.exports = {
+  wrapElementForAccess: wrapElementForAccess
+};

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -2,23 +2,10 @@ var _ = require('lodash');
 var bson = require('bson');
 var util = require('util');
 
-var log = require('../lib/log');
+var log = require('./log');
+var utils = require('./utils');
  
 var logger;
-
-// Allows comparing ObjectIDs loaded from different modules.
-function isObjectId(value) {
-  return value && value.constructor && value.constructor.name === 'ObjectID';
-}
-
-// Helper for _.isEqual to customize ObjectID comparison.  May also be used
-// directly, given that values being compared are ObjectIDs.
-function objectIdEquals(value1, value2) {
-  if (isObjectId(value1) && isObjectId(value2)) {
-    return value1.equals(value2);
-  }
-  return undefined;
-}
 
 // Evaluates matching of a top-level expression which can be either a logical
 // operator expression or a field expression.  Returns true if the element in
@@ -148,9 +135,9 @@ function evaluateOperator(context, operator, value, options) {
       return 0 <= _.findIndex(array, function(element) {
         return element instanceof Date && +element === timestamp;
       });
-    } else if (isObjectId(value)) {
+    } else if (utils.isObjectId(value)) {
       return 0 <= _.findIndex(array, function(element) {
-        return objectIdEquals(value, element);
+        return utils.objectIdEquals(value, element);
       });
     } else {
       return _.contains(array, value);
@@ -171,7 +158,7 @@ function evaluateOperator(context, operator, value, options) {
           // bounds elements or their children.
           return context.value === null;
         } else {
-          return context.exists && _.isEqual(context.value, value, objectIdEquals);
+          return context.exists && utils.isEqual(context.value, value);
         }
       };
       break;
@@ -184,7 +171,7 @@ function evaluateOperator(context, operator, value, options) {
       break;
     case '$gte':
       comparer = function(context, value) {
-        return _.isEqual(context.value, value, objectIdEquals) ||
+        return utils.isEqual(context.value, value) ||
           (objectsComparable(context, value) && context.value > value);
       };
       break;
@@ -195,7 +182,7 @@ function evaluateOperator(context, operator, value, options) {
       break;
     case '$lte':
       comparer = function(context, value) {
-        return _.isEqual(context.value, value, objectIdEquals) ||
+        return utils.isEqual(context.value, value) ||
           (objectsComparable(context, value) && context.value < value);
       }
       break;
@@ -415,6 +402,9 @@ module.exports = {
     logger = log.getLogger();
   },
   filterItems: function(documents, selector) {
+    if (!selector || utils.isEmpty(selector)) {
+      return documents;
+    }
     return _.filter(documents, function(doc) {
       var documentContext = {
         path: [],

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -45,29 +45,6 @@ that = {
     return dest;
   },
 
-  // Determines whether a value is an operator (i.e., starts with a $ sign).
-  // Assumes the value is a string.
-  isOperator: function(value) {
-    return value.length > 0 && value[0] === '$';
-  },
-
-  isEmpty: function (obj) {
-    for (var prop in obj) {
-      if (obj.hasOwnProperty(prop)) {
-        return false;
-      }
-    }
-    return true;
-  },
-
-  cloneDocuments: function cloneDocuments(doc) {
-    return _.cloneDeep(
-      doc,
-      function(value) {
-        return value instanceof ObjectID ? new ObjectID(value) : undefined;
-      });
-  },
-
   clone: function (src) {
     return JSON.parse(JSON.stringify(src));
   },

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -6,6 +6,10 @@ var helper = require('./helper');
 var filter = require('./filter');
 var projection = require('./projection');
 var update = require('./update');
+var utils = require('./utils');
+var ElementWrapper = require('./element-wrapper');
+
+var wrapElementForAccess = ElementWrapper.wrapElementForAccess;
 
 var logger;
 
@@ -14,7 +18,7 @@ function getCollection(clientReqMsg) {
 }
 
 function keyIsOperator(value, key) {
-  return helper.isOperator(key);
+  return utils.isOperator(key);
 }
 
 that = {
@@ -33,11 +37,16 @@ that = {
         case helper.OP_QUERY:
           clientReqMsg = helper.fromOpQueryBuf(header, buf);
           if (clientReqMsg.fullCollectionName.match(/\.\$cmd$/)) {
-            if (clientReqMsg.query && clientReqMsg.query.findandmodify) {
-              that.doFindAndModify(socket, clientReqMsg);
-            } else {
-              that.doCmdQuery(socket, clientReqMsg);
+            if (clientReqMsg.query) {
+              if (clientReqMsg.query.findandmodify) {
+                that.doFindAndModify(socket, clientReqMsg);
+                break;
+              } else if (clientReqMsg.query.distinct) {
+                that.doDistinct(socket, clientReqMsg);
+                break;
+              }
             }
+            that.doCmdQuery(socket, clientReqMsg);
           } else {
             that.doQuery(socket, clientReqMsg);
           }
@@ -109,12 +118,7 @@ that = {
     var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
     var collection = that.mocks[dbName][clientReqMsg.query.count];
     var query = clientReqMsg.query.query;
-    var docs;
-    if (query && !helper.isEmpty(query)) {
-      docs = filter.filterItems(collection, query);
-    } else {
-      docs = collection;
-    }
+    var docs = filter.filterItems(collection, query);
     var reply = {documents: {ok: true, n: docs.length}};
     var replyBuf = helper.toOpReplyBuf(clientReqMsg, reply);
     socket.write(replyBuf);
@@ -132,11 +136,7 @@ that = {
         throw new Error(
           'BadValue Projection cannot have a mix of inclusion and exclusion.');
       }
-      if (query && !helper.isEmpty(query)) {
-        docs = filter.filterItems(collection, query);
-      } else {
-        docs = collection || [];
-      }
+      docs = filter.filterItems(collection, query);
     } catch (err) {
       if (err.message.match(/^BadValue /)) {
         var reply = {documents: [{'$err': err.message}]};
@@ -169,16 +169,12 @@ that = {
     });
   },
   doDelete: function (socket, clientReqMsg) {
-    var collection, i, item, key, match, docs;
+    var collection, i, item, key, match;
     logger.trace('doDelete');
     collection = getCollection(clientReqMsg);
     that.affectedDocuments = 0;
     i = 0;
-    if (clientReqMsg.selector && !helper.isEmpty(clientReqMsg.selector)) {
-      docs = filter.filterItems(collection, clientReqMsg.selector);
-    } else {
-      docs = collection;
-    }
+    var docs = filter.filterItems(collection, clientReqMsg.selector);
     while (i < collection.length) {
       item = collection[i];
       if (docs.indexOf(item) !== -1) {
@@ -192,12 +188,7 @@ that = {
   doUpdate: function (socket, clientReqMsg) {
     logger.trace('doUpdate');
     var collection = getCollection(clientReqMsg);
-    var docs;
-    if (clientReqMsg.selector && !helper.isEmpty(clientReqMsg.selector)) {
-      docs = filter.filterItems(collection, clientReqMsg.selector);
-    } else {
-      docs = collection;
-    }
+    var docs = filter.filterItems(collection, clientReqMsg.selector);
     that.affectedDocuments = 0;
     var updateContainsOperators = _.any(clientReqMsg.update, keyIsOperator);
     var updateContainsOnlyOperators = _.every(
@@ -212,7 +203,7 @@ that = {
     var literalSubfield = _.findKey(
       clientReqMsg.update,
       function(value, key) {
-        return !helper.isOperator(key) && _.contains(key, '.');
+        return !utils.isOperator(key) && _.contains(key, '.');
       });
     if (literalSubfield) {
       that.lastError = util.format(
@@ -245,16 +236,11 @@ that = {
     var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
     var collectionName = clientReqMsg.query.findandmodify;
     var collection = that.mocks[dbName][collectionName] || [];
-    var docs;
-    if (clientReqMsg.query && !helper.isEmpty(clientReqMsg.query.query)) {
-      docs = filter.filterItems(collection, clientReqMsg.query.query);
-    } else {
-      docs = collection;
-    }
+    var docs = filter.filterItems(collection, clientReqMsg.query.query);
     var updateKeys = Object.keys(clientReqMsg.query.update || {});
-    var firstOperatorIndex = _.findIndex(updateKeys,helper.isOperator);
+    var firstOperatorIndex = _.findIndex(updateKeys, utils.isOperator);
     var firstNonOperatorIndex = _.findIndex(updateKeys, function(key) {
-      return !helper.isOperator(key);
+      return !utils.isOperator(key);
     });
     if (firstOperatorIndex >= 0 && firstNonOperatorIndex >= 0) {
       var errorMessage;
@@ -275,7 +261,7 @@ that = {
     var literalSubfield = _.findKey(
       clientReqMsg.query.update,
       function(value, key) {
-        return !helper.isOperator(key) && _.contains(key, '.');
+        return !utils.isOperator(key) && _.contains(key, '.');
       });
     if (literalSubfield) {
       writeErrorReply(
@@ -295,7 +281,7 @@ that = {
     }
     var returnedDoc = null;
     if (!clientReqMsg.query.new) {
-      returnedDoc = helper.cloneDocuments(docs[0]);
+      returnedDoc = utils.cloneDocuments(docs[0]);
     }
     var upsertedDoc;
     if (clientReqMsg.query.update) {
@@ -340,6 +326,36 @@ that = {
       [returnedDoc],
       clientReqMsg.query.fields)[0];
     var reply = {documents: {value: returnedDoc}};
+    var replyBuf = helper.toOpReplyBuf(clientReqMsg, reply);
+    socket.write(replyBuf);
+  },
+
+  doDistinct: function(socket, clientReqMsg) {
+    var key = clientReqMsg.query.key;
+    var query = clientReqMsg.query.query;
+
+    logger.trace('doFindAndModify');
+    var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
+    var collectionName = clientReqMsg.query.distinct;
+    var collection = that.mocks[dbName][collectionName] || [];
+    var docs = filter.filterItems(collection, query);
+
+    var results = [];
+    if (_.isString(key)) {
+      var elements = _(docs).map(function(doc) {
+        return wrapElementForAccess(doc, key).getValue();
+      }).reject(_.isUndefined).value();
+
+      _.forEach(elements, function(element) {
+        var found = _.find(results, function(value) {
+          return utils.isEqual(element, value);
+        });
+        if (!found) {
+          results.push(element);
+        }
+      });
+    }
+    var reply = {documents: {ok: true, values: results}};
     var replyBuf = helper.toOpReplyBuf(clientReqMsg, reply);
     socket.write(replyBuf);
   }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -334,7 +334,7 @@ that = {
     var key = clientReqMsg.query.key;
     var query = clientReqMsg.query.query;
 
-    logger.trace('doFindAndModify');
+    logger.trace('doDistinct');
     var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
     var collectionName = clientReqMsg.query.distinct;
     var collection = that.mocks[dbName][collectionName] || [];

--- a/lib/projection.js
+++ b/lib/projection.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var ObjectID = require('bson').ObjectID;
 
-var helper = require('./helper');
+var utils = require('./utils');
 
 function selectField(doc, fieldSelector) {
   if (fieldSelector.length > 0) {
@@ -82,7 +82,7 @@ function getProjection(docs, projectionDoc) {
     });
   } else {
     result = _.map(docs, function(doc) {
-      var resultDoc = helper.cloneDocuments(doc);
+      var resultDoc = utils.cloneDocuments(doc);
       _.forEach(excludeFields, function(selector) {
         excludeField(resultDoc, selector.split('.'));
       });

--- a/lib/update.js
+++ b/lib/update.js
@@ -2,100 +2,10 @@ var _ = require('lodash');
 var util = require('util')
 var ObjectID = require('bson').ObjectID;
 
-var helper = require('./helper');
+var utils = require('./utils');
+var ElementWrapper = require('./element-wrapper');
 
-function InputDataError(message) {
-  this.message = message;
-}
-InputDataError.prototype = new Error();
-
-// Determines whethe value is an atomic value (i.e., not an object or an
-// array).
-function isAtomic(value) {
-  if (typeof value === 'number') {
-    return true;
-  } else if (typeof value === 'string') {
-    return true;
-  } else if (value instanceof Date) {
-    return true;
-  } else if (value instanceof ObjectID) {
-    return true;
-  } else if (value === null) {
-    return true;
-  }
-  return false;
-}
-
-// Wraps an element of doc accessible via path in the dot notation
-// (http://docs.mongodb.org/manual/core/document/#document-dot-notation) in a
-// handler object that allows getting or setting the value of the element.  For
-// example, wrapElementForAccess({a: {b: 1}}, 'a.b').getValue() will return 1.
-// When getting a value, if leaf or intermediate children do not exist, the
-// result will be undefined. For example, wrapElementForAccess({a}, 'b') will
-// return undefined.  When setting a value which parent does not exists, the
-// parent will be created. For example, after running this code:
-//   var doc = {a: 1};
-//   wrapElementForAccess(doc, 'b.c').setValue(5);
-// doc will be {a: 1, b: {c: 5}}.
-//
-function wrapElementForAccess(doc, path) {
-  function newDocTraversalError(selector) {
-    return new InputDataError(util.format(
-      'cannot use the part (%s of %s) to traverse the element (%s)',
-      selector, path, util.format(doc)));
-  };
-  var wrapElement = function(parentElem, selector) {
-    var doc = parentElem.getValue();
-
-    return {
-      getValue: function() {
-        return _.isUndefined(doc) ? doc : doc[selector];
-      },
-      setValue: function(value) {
-        if (_.isArray(doc)) {
-          if (selector.match(/^[0-9]$/)) {
-            selector = parseInt(selector);
-            while (doc.length <= selector) {
-              doc.push(null);
-            }
-          } else {
-            throw newDocTraversalError(selector);
-          }
-        } else if (isAtomic(doc) && !_.isUndefined(doc)) {
-          throw newDocTraversalError(selector);
-        }
-        if (_.isUndefined(doc)) {
-          doc = {};
-          parentElem.setValue(doc);
-        }
-        doc[selector] = value;
-      },
-      deleteValue: function() {
-        if (_.isArray(doc) && selector.match(/^[0-9]$/)) {
-          var index = parseInt(selector);
-          if (index < doc.length) {
-            doc[index] = null;
-          }
-        } else if (_.isPlainObject(doc)) {
-          delete doc[selector];
-        }
-      }
-    };
-  }
-
-  var wrapElementAtPath = function(parentElem, selectors) {
-    if (selectors.length === 0) {
-      return parentElem;
-    }
-    var currentElem = wrapElement(parentElem, selectors[0]);
-    if (currentElem.error) {
-      return currentElem;
-    }
-    return wrapElementAtPath(currentElem, selectors.slice(1));
-  };
-
-  return wrapElementAtPath({getValue: function() { return doc; }}, path.split('.'));
-}
+var wrapElementForAccess = ElementWrapper.wrapElementForAccess;
 
 // Assuming source is a MongoDB selector document, retrieves values from
 // equality comparisons (e,g, {a: 1}) and set them in destination.  If source
@@ -106,9 +16,9 @@ function wrapElementForAccess(doc, path) {
 //
 function copyEqualityValues(destination, source) {
   _.forOwn(source, function(value, key) {
-    if (!helper.isOperator(key)) {
-      if (isAtomic(value)) {
-        if (!helper.isOperator(value)) {
+    if (!utils.isOperator(key)) {
+      if (utils.isAtomic(value)) {
+        if (!utils.isOperator(value)) {
           wrapElementForAccess(destination, key).setValue(value);
         }
       } else {
@@ -144,7 +54,7 @@ function arrayPull(arr, value) {
 function update(docs, query, updateDoc, multiUpdate, upsertedDoc, context) {
   var updateContainsOperators = _.any(
     updateDoc,
-    function(value, key) { return helper.isOperator(key); });
+    function(value, key) { return utils.isOperator(key); });
 
   if (upsertedDoc && updateContainsOperators) {
     copyEqualityValues(upsertedDoc, query);
@@ -191,7 +101,7 @@ function update(docs, query, updateDoc, multiUpdate, upsertedDoc, context) {
               var arr = property.getValue();
               if (_.isUndefined(arr)) continue;
               if (!_.isArray(arr)) {
-                throw new InputDataError(
+                throw new utils.InputDataError(
                   'Cannot apply $pull to a non-array value');
               }
               arrayPull(arr, value);
@@ -214,7 +124,7 @@ function update(docs, query, updateDoc, multiUpdate, upsertedDoc, context) {
                 default:
                   valuesTypeName = 'embedded document';
               }
-              throw new InputDataError(
+              throw new utils.InputDataError(
                 "$pushAll requires an array of values but was given an " + values);
             }
             var property = wrapElementForAccess(doc, propKey);
@@ -224,11 +134,11 @@ function update(docs, query, updateDoc, multiUpdate, upsertedDoc, context) {
             } else if (_.isArray(arr)) {
               property.setValue(arr.concat(values));
             } else {
-              throw new InputDataError(
+              throw new utils.InputDataError(
                 "The field '" + propKey + "' must be an array.");
             }
           }
-        } else if (helper.isOperator(updateKey)) {
+        } else if (utils.isOperator(updateKey)) {
           throw new Error('update value "' + updateKey + '" not supported');
         } else {
           // Literal value to set.
@@ -241,7 +151,7 @@ function update(docs, query, updateDoc, multiUpdate, upsertedDoc, context) {
       upsertedDoc._id = new ObjectID();
     }
   } catch (error) {
-    if (error instanceof InputDataError) {
+    if (error instanceof utils.InputDataError) {
       context.lastError = error.message;
     } else {
       throw error;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var _ = require('lodash');
+var ObjectID = require('bson').ObjectID;
+
+function InputDataError(message) {
+  this.message = message;
+}
+InputDataError.prototype = new Error();
+
+
+// Allows comparing ObjectIDs loaded from different modules.
+function isObjectId(value) {
+  return value && value.constructor && value.constructor.name === 'ObjectID';
+}
+
+// Helper for _.isEqual to customize ObjectID comparison.  May also be used
+// directly, given that values being compared are ObjectIDs.
+function objectIdEquals(value1, value2) {
+  if (isObjectId(value1) && isObjectId(value2)) {
+    return value1.equals(value2);
+  }
+  return undefined;
+}
+
+module.exports = {
+  // Determines whether a value is an operator (i.e., starts with a $ sign).
+  // Assumes the value is a string.
+  isOperator: function(value) {
+    return value.length > 0 && value[0] === '$';
+  },
+
+  isEmpty: function (obj) {
+    for (var prop in obj) {
+      if (obj.hasOwnProperty(prop)) {
+        return false;
+      }
+    }
+    return true;
+  },
+
+  // Determines whethe value is an atomic value (i.e., not an object or an
+  // array).
+  isAtomic: function isAtomic(value) {
+    if (typeof value === 'number') {
+      return true;
+    } else if (typeof value === 'string') {
+      return true;
+    } else if (value instanceof Date) {
+      return true;
+    } else if (value instanceof ObjectID) {
+      return true;
+    } else if (value === null) {
+      return true;
+    }
+    return false;
+  },
+
+  cloneDocuments: function cloneDocuments(doc) {
+    return _.cloneDeep(
+      doc,
+      function(value) {
+        return value instanceof ObjectID ? new ObjectID(value) : undefined;
+      });
+  },
+
+  // Allows comparing ObjectIDs loaded from different modules.
+  isObjectId: isObjectId,
+
+  // Helper for _.isEqual to customize ObjectID comparison.  May also be used
+  // directly, given that values being compared are ObjectIDs.
+  objectIdEquals: objectIdEquals,
+
+  // MongoDB-style object comparison.  ObjectIDs use their own comparison code.
+  isEqual: function isEqual(value1, value2) {
+    return _.isEqual(value1, value2, objectIdEquals);
+  },
+
+
+  InputDataError: InputDataError
+};

--- a/test/testInProcess.js
+++ b/test/testInProcess.js
@@ -149,7 +149,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     });
   });
 
-  describe('delete', function() {
+  describe('remove', function() {
     it('basic', function(done) {
       config.mocks.fakedb.simpleitems = [{key: 'value1'}, {key: 'value2'}];
       SimpleItem.remove({key: 'value1'}, function(error) {
@@ -1225,6 +1225,69 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       NumberItem.count({key: {$gt: 1}}, function(error, n) {
         if (error) return done(error);
         expect(n).to.equal(2);
+        done();
+      });
+    });
+  });
+
+  describe('distinct', function() {
+    it('finds distinct field values', function(done) {
+      config.mocks.fakedb.freeitems = [{key: 1}, {key: 2}, {key: 3}, {key2: 4}];
+      FreeItem.collection.distinct('key', function(error, values) {
+        if (error) return done(error);
+        expect(values).to.deep.equal([1, 2, 3]);
+        done();
+      });
+    });
+
+    it('finds distinct subfiled values', function(done) {
+      config.mocks.fakedb.freeitems = [
+        {a: {b: 'x'}, c: 1},
+        {a: {b: 'y'}},
+        {a: {c: 'z'}}
+      ];
+      FreeItem.collection.distinct('a.b', function(error, values) {
+        if (error) return done(error);
+        expect(values).to.deep.equal(['x', 'y']);
+        done();
+      });
+    });
+
+    it('supports filtering', function(done) {
+      config.mocks.fakedb.freeitems = [{key: 1}, {key: 2}, {key: 3}];
+      FreeItem.collection.distinct(
+        'key',
+        {key: {'$gt': 1}},
+        function(error, values) {
+          if (error) return done(error);
+          expect(values).to.deep.equal([2, 3]);
+          done();
+        });
+    });
+
+    it('handles empty collection', function(done) {
+      config.mocks.fakedb.freeitems = [];
+      FreeItem.collection.distinct('key', function(error, values) {
+        if (error) return done(error);
+        expect(values).to.deep.equal([]);
+        done();
+      });
+    });
+
+    it('returns empty array if field parameter is invalid', function(done) {
+      config.mocks.fakedb.freeitems = [{key: 1}, {key: 2}, {key: 3}];
+      FreeItem.collection.distinct(42, function(error, values) {
+        if (error) return done(error);
+        expect(values).to.deep.equal([]);
+        done();
+      });
+    });
+
+    it('ignores invalid query parameter', function(done) {
+      config.mocks.fakedb.freeitems = [{key: 1}, {key: 2}, {key: 3}];
+      FreeItem.collection.distinct('key', 3, function(error, values) {
+        if (error) return done(error);
+        expect(values).to.deep.equal([1, 2, 3]);
         done();
       });
     });

--- a/test/testInProcess.js
+++ b/test/testInProcess.js
@@ -1253,6 +1253,19 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       });
     });
 
+    it('finds distinct compound values', function(done) {
+      config.mocks.fakedb.freeitems = [
+        {a: {b: 'x'}, c: 1},
+        {a: {b: 'y'}},
+        {a: ['x', 42]}
+      ];
+      FreeItem.collection.distinct('a', function(error, values) {
+        if (error) return done(error);
+        expect(values).to.deep.equal([{b: 'x'}, {b: 'y'}, ['x', 42]]);
+        done();
+      });
+    });
+
     it('supports filtering', function(done) {
       config.mocks.fakedb.freeitems = [{key: 1}, {key: 2}, {key: 3}];
       FreeItem.collection.distinct(


### PR DESCRIPTION
This implements the MongoDB's `collection.distinct` command. This required a couple of re-factorings. I needed to reuse `wrapElementForAccess` so it had to go into a separate module (I have vague plans to turn it into an object). Some other often used methods went into a new `utils` module. The `helper` module is really a protocol parser/marshaler and as such not a good place for them - I plan to clean it up and rename later.

@parkr @MrNice - please lend your :eyes: to this.