### PR TITLE
Re-factoring and formatting changes.

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -18,40 +18,12 @@ that = {
   OP_INSERT: 2002,
   OP_QUERY: 2004,
   OP_DELETE: 2006,
-  copyProperties: function (src, dest, onlyExisting, exclude) {
-    var key;
-    if (_.isUndefined(onlyExisting)) {
-      onlyExisting = !_.isUndefined(dest);
-    }
-    if (_.isUndefined(dest)) {
-      dest = {};
-    }
-    for (key in src) {
-      if (exclude && exclude.indexOf(key) !== -1) {
-        continue;
-      }
-      if (src.hasOwnProperty(key) && (!onlyExisting || dest.hasOwnProperty(key))) {
-        if (typeof src[key] === 'object' && typeof dest[key] === 'object' && !(dest[key] instanceof Array) && dest[key] !== null) {
-          if (src[key] === null) {
-            dest[key] = src[key];
-          } else {
-            that.copyProperties(src[key], dest[key], onlyExisting);
-          }
-        } else {
-          dest[key] = src[key];
-        }
-      }
-    }
-    return dest;
+
+  bitIsSet: function(num, bit) {
+    return (num & (1 << bit)) != 0;
   },
 
-  clone: function (src) {
-    return JSON.parse(JSON.stringify(src));
-  },
-  bitIsSet: function (num, bit) {
-    return ((num >> bit) % 2 != 0)
-  },
-  fromMsgHeaderBuf: function (buf) {
+  fromMsgHeaderBuf: function(buf) {
     var i, msgHeader, headerNames, int32Value;
     headerNames = ['messageLength', 'requestID', 'responseTo', 'opCode'];
     i = 0;
@@ -66,12 +38,13 @@ that = {
     }
     return msgHeader;
   },
-  fromOpQueryBuf: function (header, buf) {
+
+  fromOpQueryBuf: function(header, buf) {
     var opQuery, i;
     i = 4 * 4;
     opQuery = {};
     opQuery.header = header;
-    (function () {
+    (function() {
       var flags = buf.readInt32LE(i);
       opQuery.flags = {
         tailableCursor: that.bitIsSet(flags, 1),
@@ -84,21 +57,21 @@ that = {
       };
       i += 4;
     })();
-    (function () {
+    (function() {
       var j = i;
       while (buf[j] !== 0) j++;
       opQuery.fullCollectionName = buf.toString('utf-8', i, j);
       i = j + 1;
     })();
-    (function () {
+    (function() {
       opQuery.numberToSkip = buf.readInt32LE(i);
       i += 4;
     })();
-    (function () {
+    (function() {
       opQuery.numberToReturn = buf.readInt32LE(i);
       i += 4;
     })();
-    (function () {
+    (function() {
       var bson, docs;
       docs = [];
       bson = new BSON();
@@ -111,25 +84,25 @@ that = {
     buf.bytesRead = i;
     return opQuery;
   },
-  fromOpInsertBuf: function (header, buf) {
+  fromOpInsertBuf: function(header, buf) {
     var opInsert, i;
     i = 4 * 4;
     opInsert = {};
     opInsert.header = header;
-    (function () {
+    (function() {
       var flags = buf.readInt32LE(i);
       opInsert.flags = {
         continueOnError: that.bitIsSet(flags, 1)
       };
       i += 4;
     })();
-    (function () {
+    (function() {
       var j = i;
       while (buf[j] !== 0) j++;
       opInsert.fullCollectionName = buf.toString('utf-8', i, j);
       i = j + 1;
     })();
-    (function () {
+    (function() {
       var bson, docs;
       docs = [];
       bson = new BSON();
@@ -141,26 +114,27 @@ that = {
     buf.bytesRead = i;
     return opInsert;
   },
-  fromOpDeleteBuf: function (header, buf) {
+
+  fromOpDeleteBuf: function(header, buf) {
     var opDelete, i;
     i = 4 * 4;
     opDelete = {};
     opDelete.header = header;
     i += 4;
-    (function () {
+    (function() {
       var j = i;
       while (buf[j] !== 0) j++;
       opDelete.fullCollectionName = buf.toString('utf-8', i, j);
       i = j + 1;
     })();
-    (function () {
+    (function() {
       var flags = buf.readInt32LE(i);
       opDelete.flags = {
         singleRemove: that.bitIsSet(flags, 1)
       };
       i += 4;
     })();
-    (function () {
+    (function() {
       var bson, docs;
       docs = [];
       bson = new BSON();
@@ -170,19 +144,20 @@ that = {
     buf.bytesRead = i;
     return opDelete;
   },
-  fromOpUpdateBuf: function (header, buf) {
+
+  fromOpUpdateBuf: function(header, buf) {
     var opUpdate, i;
     i = 4 * 4;
     opUpdate = {};
     opUpdate.header = header;
     i += 4;
-    (function () {
+    (function() {
       var j = i;
       while (buf[j] !== 0) j++;
       opUpdate.fullCollectionName = buf.toString('utf-8', i, j);
       i = j + 1;
     })();
-    (function () {
+    (function() {
       var flags = buf.readInt32LE(i);
       opUpdate.flags = {
         upsert: that.bitIsSet(flags, 0),
@@ -190,7 +165,7 @@ that = {
       };
       i += 4;
     })();
-    (function () {
+    (function() {
       var bson, docs;
       docs = [];
       bson = new BSON();
@@ -203,7 +178,8 @@ that = {
     buf.bytesRead = i;
     return opUpdate;
   },
-  toOpReplyBuf: function (opQuery, reply) {
+
+  toOpReplyBuf: function(opQuery, reply) {
     var i, buffers, buf, documents;
     reply.header = reply.header || {};
     reply.header.requestID = reply.header.requestID || 0;
@@ -225,19 +201,19 @@ that = {
     buffers = [ new Buffer(36) ];
     buf = buffers[0];
     i = 4;
-    (function () {
+    (function() {
       buf.writeUInt32LE(reply.header.requestID, i);
       i += 4;
     })();
-    (function () {
+    (function() {
       buf.writeUInt32LE(reply.header.responseTo, i);
       i += 4;
     })();
-    (function () {
+    (function() {
       buf.writeUInt32LE(reply.header.opCode, i);
       i += 4;
     })();
-    (function () {
+    (function() {
       var nibble;
       nibble = reply.responseFlags.cursorNotFound ? 1 : 0
         || reply.responseFlags.queryFailure ? 2 : 0
@@ -246,37 +222,33 @@ that = {
       buf.writeUInt32LE(nibble, i);
       i += 4;
     })();
-    (function () {
+    (function() {
       buf.writeUInt32LE(reply.cursorID, i);
       i += 4;
       buf.writeUInt32LE(reply.cursorID << 32, i);
       i += 4;
     })();
-    (function () {
+    (function() {
       buf.writeUInt32LE(reply.startingFrom, i);
       i += 4;
     })();
-    (function () {
+    (function() {
       buf.writeUInt32LE(reply.numberReturned, i);
       i += 4;
     })();
-    (function () {
+    (function() {
       var bson, serDoc;
       bson = new BSON();
-      reply.documents.forEach(function (document) {
+      reply.documents.forEach(function(document) {
         serDoc = bson.serialize(document);
         buffers.push(serDoc);
       });
     })();
-    (function () {
+    (function() {
       buf = Buffer.concat(buffers);
       buf.writeUInt32LE(buf.length, 0);
     })();
     return buf;
-  },
-  safeCallback: function (callback) {
-    return callback || function () {
-    };
   }
 };
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -4,13 +4,13 @@ var log4js = require('log4js')
 that = {
   category: null,
   level: 'INFO',
-  init: function (config) {
+  init: function(config) {
     config = config || {};
     log4js.configure(config.log4js);
     that.category = config.category || that.category;
     that.level = config.level || that.level;
   },
-  getLogger: function (category) {
+  getLogger: function(category) {
     var logger;
     logger = log4js.getLogger(category || that.category);
     logger.setLevel(that.level);

--- a/lib/mongodb-fs.js
+++ b/lib/mongodb-fs.js
@@ -1,50 +1,57 @@
-var net = require('net')
-  , childProcess = require('child_process')
-  , helper = require('./helper')
-  , log = require('../lib/log')
-  , processor = require('./processor')
-  , that, logger;
+var _ = require('lodash');
+var childProcess = require('child_process');
+var net = require('net');
 
-that = {
-  server: null,
+var log = require('./log');
+var processor = require('./processor');
+var utils = require('./utils');
+
+var that = {
   config: {
     port: 27017,
     fork: false
   },
+  server: null,
   running: false,
   child: null,
-  init: function (config) {
-    log.init(config.log);
-    logger = log.getLogger();
-    helper.copyProperties(config, that.config, false);
-    processor.init(config.mocks);
+  logger: null,
+
+  init: function(config) {
+    _.extend(that.config, config);
+    log.init(that.config.log);
+    that.logger = log.getLogger();
+    processor.init(that.config.mocks);
   },
-  start: function (callback) {
-    callback = helper.safeCallback(callback);
+
+  start: function(callback) {
+    callback = utils.safeCallback(callback);
+
     if (that.config.fork) {
       that.child = childProcess.fork(__filename);
       that.child.send({ action: 'start', config: that.config });
-      that.child.on('message', function (data) {
+      that.child.on('message', function(data) {
         if (data.state === 'started') {
           callback(data.err);
         }
       });
       return;
     }
-    logger.trace('starting server');
+    that.logger.trace('starting server');
     that.server = net.createServer(processor.process);
-    that.server.listen(that.config.port, function (err) {
-      logger.trace('server ready, listening to port ', that.config.port);
+    that.server.listen(that.config.port, function(err) {
+      that.logger.trace('server ready, listening to port ', that.config.port);
       that.running = true;
       callback(err);
     });
   },
-  stop: function (callback) {
-    callback = helper.safeCallback(callback);
-    logger.trace('closing server');
+
+  stop: function(callback) {
+    callback = utils.safeCallback(callback);
+    that.logger.trace('closing server');
+
     if (that.child) {
       that.child.send({ action: 'stop' });
-      that.child.on('message', function (data) {
+      that.child.on('message', function(data) {
         if (data.state === 'stopped') {
           callback(data.err);
         }
@@ -52,13 +59,14 @@ that = {
       });
       return;
     }
-    that.server.close(function () {
-      logger.trace('server closed');
+    that.server.close(function() {
+      that.logger.trace('server closed');
       that.running = false;
       callback();
     });
   },
-  isRunning: function () {
+
+  isRunning: function() {
     return that.running || that.child;
   }
 };
@@ -66,16 +74,16 @@ that = {
 if (module.parent) {
   module.exports = that;
 } else {
-  process.on('message', function (data) {
+  process.on('message', function(data) {
     if (data.action === 'start') {
       data.config.fork = false;
       that.init(data.config);
-      that.start(function (err) {
-        process.send({ state: 'started', err: err });
+      that.start(function(err) {
+        process.send({state: 'started', err: err});
       });
     } else if (data.action === 'stop') {
-      that.stop(function (err) {
-        process.send({ state: 'stopped', err: err });
+      that.stop(function(err) {
+        process.send({state: 'stopped', err: err});
         process.exit(0);
       });
     }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -23,14 +23,16 @@ function keyIsOperator(value, key) {
 
 that = {
   mocks: null,
+
   init: function(mocks) {
     logger = require('../lib/log').getLogger();
     that.mocks = mocks;
     filter.init();
   },
-  process: function (socket) {
+
+  process: function(socket) {
     logger.trace('new socket');
-    var processSocketData = function (buf) {
+    var processSocketData = function(buf) {
       var header, clientReqMsg;
       header = helper.fromMsgHeaderBuf(buf);
       switch (header.opCode) {
@@ -77,11 +79,12 @@ that = {
         logger.error('Uncaught exception processing socket data: ', err);
       }
     });
-    socket.on('end', function () {
+    socket.on('end', function() {
       logger.trace('socket disconnect');
     });
   },
-  doCmdQuery: function (socket, clientReqMsg) {
+
+  doCmdQuery: function(socket, clientReqMsg) {
     var reply, replyBuf;
     logger.trace('doCmdQuery');
     if (clientReqMsg.query['ismaster']) {
@@ -113,7 +116,8 @@ that = {
       throw new Error('not supported');
     }
   },
-  doCount: function (socket, clientReqMsg) {
+
+  doCount: function(socket, clientReqMsg) {
     logger.trace('doCount');
     var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
     var collection = that.mocks[dbName][clientReqMsg.query.count];
@@ -123,7 +127,8 @@ that = {
     var replyBuf = helper.toOpReplyBuf(clientReqMsg, reply);
     socket.write(replyBuf);
   },
-  doQuery: function (socket, clientReqMsg) {
+
+  doQuery: function(socket, clientReqMsg) {
     var collection, docs, replyBuf;
     logger.trace('doQuery');
     collection = getCollection(clientReqMsg);
@@ -158,17 +163,19 @@ that = {
     replyBuf = helper.toOpReplyBuf(clientReqMsg, { documents: docs });
     socket.write(replyBuf);
   },
-  doInsert: function (socket, clientReqMsg) {
+
+  doInsert: function(socket, clientReqMsg) {
     var collection;
     logger.trace('doInsert');
     collection = getCollection(clientReqMsg);
     that.affectedDocuments = 0;
-    clientReqMsg.documents.forEach(function (doc) {
+    clientReqMsg.documents.forEach(function(doc) {
       collection.push(doc);
       that.affectedDocuments++;
     });
   },
-  doDelete: function (socket, clientReqMsg) {
+
+  doDelete: function(socket, clientReqMsg) {
     var collection, i, item, key, match;
     logger.trace('doDelete');
     collection = getCollection(clientReqMsg);
@@ -185,7 +192,8 @@ that = {
       }
     }
   },
-  doUpdate: function (socket, clientReqMsg) {
+
+  doUpdate: function(socket, clientReqMsg) {
     logger.trace('doUpdate');
     var collection = getCollection(clientReqMsg);
     var docs = filter.filterItems(collection, clientReqMsg.selector);
@@ -225,6 +233,7 @@ that = {
       upsertedDoc,
       that);
   },
+
   doFindAndModify: function(socket, clientReqMsg) {
     function writeErrorReply(clientReqMsg, errorMessage) {
       var reply = {documents: [{ok: false, errmsg: errorMessage}]};

--- a/lib/update.js
+++ b/lib/update.js
@@ -60,7 +60,7 @@ function update(docs, query, updateDoc, multiUpdate, upsertedDoc, context) {
     copyEqualityValues(upsertedDoc, query);
   }
   try {
-    _.forEach(docs, function (doc, index) {
+    _.forEach(docs, function(doc, index) {
       if (!multiUpdate && index > 0) {
         // multi is off and we have already updated one document.
         return false;  // Exit the loop.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,7 +30,7 @@ module.exports = {
     return value.length > 0 && value[0] === '$';
   },
 
-  isEmpty: function (obj) {
+  isEmpty: function(obj) {
     for (var prop in obj) {
       if (obj.hasOwnProperty(prop)) {
         return false;
@@ -76,6 +76,9 @@ module.exports = {
     return _.isEqual(value1, value2, objectIdEquals);
   },
 
+  safeCallback: function(callback) {
+    return callback || function() {};
+  },
 
   InputDataError: InputDataError
 };

--- a/test/mini-sample.js
+++ b/test/mini-sample.js
@@ -44,17 +44,17 @@ mongodbFs.init({
   }
 });
 
-mongodbFs.start(function (err) {
-  mongoose.connect('mongodb://localhost:27027/fakedb', { server: { poolSize: 1 } }, function (err) {
+mongodbFs.start(function(err) {
+  mongoose.connect('mongodb://localhost:27027/fakedb', { server: { poolSize: 1 } }, function(err) {
     // Usual mongoose code to retreive all the contacts
     var Contact;
     Contact = mongoose.connection.model('Contact');
-    Contact.find(function (err, contacts) {
+    Contact.find(function(err, contacts) {
       //
       console.log('contacts :', contacts);
       //
-      mongoose.disconnect(function (err) { // clean death
-        mongodbFs.stop(function (err) {
+      mongoose.disconnect(function(err) { // clean death
+        mongodbFs.stop(function(err) {
           console.log('bye!');
         });
       });

--- a/test/sample2.js
+++ b/test/sample2.js
@@ -21,19 +21,19 @@ mongodbFs.init({
   }
 });
 
-mongodbFs.start(function (err) {
-  con = mongoose.createConnection('mongodb://localhost:27027/fakedb', { server: { poolSize: 1 } }, function (err) {
+mongodbFs.start(function(err) {
+  con = mongoose.createConnection('mongodb://localhost:27027/fakedb', {server: {poolSize: 1}}, function(err) {
     var MyModel, myModel;
     MyModel = con.model('MyModel');
     myModel = new MyModel({
       a: 'avalue',
       b: 'bvalue'
     });
-    myModel.save(function (err) {
-      MyModel.find(function (err, myModels) {
+    myModel.save(function(err) {
+      MyModel.find(function(err, myModels) {
         console.log('myModels :', myModels);
-        con.close(function (err) { // clean death
-          mongodbFs.stop(function (err) {
+        con.close(function(err) { // clean death
+          mongodbFs.stop(function(err) {
             console.log('bye!');
           });
         });

--- a/test/testInProcess.js
+++ b/test/testInProcess.js
@@ -97,8 +97,8 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
 
     it('run twice', function(done) {
       config.mocks.fakedb.simpleitems = [{key: 'value1'}, {key: 'value2'}];
-      SimpleItem.find(function (error, items) {});
-      SimpleItem.find(function (error, items) {
+      SimpleItem.find(function(error, items) {});
+      SimpleItem.find(function(error, items) {
         if (error) return done(error);
         expect(items).to.have.length(2);
         expect(items[0]).to.have.property('key', 'value1');
@@ -265,7 +265,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     it('push to array', function(done) {
       var id = new mongoose.Types.ObjectId;
       config.mocks.fakedb.arrayitems = [{_id: id, __v: 0, key: ['value1']}];
-      ArrayItem.findOne({_id: id}, function (error, item) {
+      ArrayItem.findOne({_id: id}, function(error, item) {
         if (error) return done(error);
         expect(item).to.have.property('key');
         item.key.push('value2');
@@ -329,7 +329,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       config.mocks.fakedb.arrayitems = [
         {_id: id, __v: 0, key: ['value1', 'value2']}
       ];
-      ArrayItem.findOne({_id: id}, function (error, item) {
+      ArrayItem.findOne({_id: id}, function(error, item) {
         if (error) return done(error);
         expect(item).to.have.property('key');
         item.key.shift();
@@ -347,7 +347,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
     it('set array value', function(done) {
       var id = new mongoose.Types.ObjectId;
       config.mocks.fakedb.arrayitems = [{_id: id, __v: 0, key: ['value1', 'value2']}];
-      ArrayItem.findOne({_id: id}, function (error, item) {
+      ArrayItem.findOne({_id: id}, function(error, item) {
         if (error) return done(error);
         expect(item).to.have.property('key');
         item.key = ['one', 'two'];
@@ -369,7 +369,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       config.mocks.fakedb.dateitems = [
         {_id: id, date: tenSecondsAgo}];
       var DateItem = mongoose.connection.model('DateItem');
-      DateItem.findOne({_id: id}, function (error, item) {
+      DateItem.findOne({_id: id}, function(error, item) {
         if (error) return done(error);
         expect(item).to.have.property('date');
         item.date = now;
@@ -390,7 +390,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       config.mocks.fakedb.datearrayitems = [
         {_id: id, date: tenSecondsAgo}];
       var DateArrayItem = mongoose.connection.model('DateArrayItem');
-      DateArrayItem.findOne({_id: id}, function (error, item) {
+      DateArrayItem.findOne({_id: id}, function(error, item) {
         if (error) return done(error);
         expect(item).to.have.property('date');
         item.date = [now];
@@ -460,7 +460,7 @@ describe('MongoDb-Fs in-process operations do not hang', function() {
       config.mocks.fakedb.simpleitems = [{key: 'value1'}];
       SimpleItem.update(
         {key: 'value1'},
-        {$set: {'key.k2.k3': 5 }}, function (err, item) {
+        {$set: {'key.k2.k3': 5 }}, function(err, item) {
         expect(err).to.exist;
         expect(err.ok).to.be.false;
         expect(err)

--- a/test/testMongoDbFs.js
+++ b/test/testMongoDbFs.js
@@ -229,7 +229,7 @@ describe('MongoDB-Fs', function() {
 
   describe('find', function() {
     it('finds all documents', function(done) {
-      Item.find(function (err, items) {
+      Item.find(function(err, items) {
         expect(err).to.not.exist;
         expect(items).to.have.length(3);
         done();
@@ -245,7 +245,7 @@ describe('MongoDB-Fs', function() {
     });
 
     it('supports skip', function(done) {
-      Item.find({}).skip(1).exec(function (err, items) {
+      Item.find({}).skip(1).exec(function(err, items) {
         expect(err).to.not.exist;
         expect(_.pluck(items, 'field1')).to.deep.equal(['value11', 'value21']);
         done();
@@ -253,7 +253,7 @@ describe('MongoDB-Fs', function() {
     });
 
     it('supports limit', function(done) {
-      Item.find({}).limit(2).exec(function (err, items) {
+      Item.find({}).limit(2).exec(function(err, items) {
         expect(err).to.not.exist;
         expect(_.pluck(items, 'field1')).to.deep.equal(['value1', 'value11']);
         done();
@@ -261,7 +261,7 @@ describe('MongoDB-Fs', function() {
     });
 
     it('supports skip together with limit', function(done) {
-      Item.find({}).skip(1).limit(1).exec(function (err, items) {
+      Item.find({}).skip(1).limit(1).exec(function(err, items) {
         expect(err).to.not.exist;
         expect(_.pluck(items, 'field1')).to.deep.equal(['value11']);
         done();


### PR DESCRIPTION
This change makes function definition formatting consistent throughout the code and deletes/moves some code from `helper.js` leaving only wire protocol related methods there. We can now safely rename it to reflect the semantics (in another PR).

@parkr, lookies, please?