### PR TITLE
Moves database operations into separate modules.

### DIFF
--- a/lib/commands/count.js
+++ b/lib/commands/count.js
@@ -6,7 +6,8 @@ var protocol = require('../protocol');
 module.exports = function doCount(socket, clientReqMsg) {
   this.logger.info('doCount');
   var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
-  var collection = this.mocks[dbName][clientReqMsg.query.count] || [];
+  var collectionName = clientReqMsg.query.count;
+  var collection = this.getCollection(dbName + '.' + collectionName);
   var query = clientReqMsg.query.query;
   var docs = filter.filterItems(collection, query);
   var reply = {documents: {ok: true, n: docs.length}};

--- a/lib/commands/count.js
+++ b/lib/commands/count.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var filter = require('../filter');
+var protocol = require('../protocol');
+
+module.exports = function doCount(socket, clientReqMsg) {
+  this.logger.info('doCount');
+  var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
+  var collection = this.mocks[dbName][clientReqMsg.query.count] || [];
+  var query = clientReqMsg.query.query;
+  var docs = filter.filterItems(collection, query);
+  var reply = {documents: {ok: true, n: docs.length}};
+  var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
+  socket.write(replyBuf);
+};

--- a/lib/commands/delete.js
+++ b/lib/commands/delete.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var _ = require('lodash');
+
+var filter = require('../filter');
+
+module.exports = function doDelete(socket, clientReqMsg) {
+  this.logger.info('doDelete');
+  var collection = this.getCollection(clientReqMsg);
+  this.affectedDocuments = 0;
+  var i = 0;
+  var docs = filter.filterItems(collection, clientReqMsg.selector);
+  while (i < collection.length) {
+    var item = collection[i];
+    if (docs.indexOf(item) !== -1) {
+      collection.splice(i, 1);
+      this.affectedDocuments++;
+    } else {
+      i++;
+    }
+  }
+};

--- a/lib/commands/distinct.js
+++ b/lib/commands/distinct.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var _ = require('lodash');
+
+var filter = require('../filter');
+var protocol = require('../protocol');
+var utils = require('../utils');
+var ElementWrapper = require('../element-wrapper');
+
+var wrapElementForAccess = ElementWrapper.wrapElementForAccess;
+
+module.exports = function doDistinct(socket, clientReqMsg) {
+  var key = clientReqMsg.query.key;
+  var query = clientReqMsg.query.query;
+
+  this.logger.info('doDistinct');
+  var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
+  var collectionName = clientReqMsg.query.distinct;
+  var collection = this.getCollection(dbName + '.' + collectionName);
+  var docs = filter.filterItems(collection, query);
+
+  var results = [];
+  if (_.isString(key)) {
+    var elements = _(docs).map(function(doc) {
+      return wrapElementForAccess(doc, key).getValue();
+    }).reject(_.isUndefined).value();
+
+    _.forEach(elements, function(element) {
+      var found = _.find(results, function(value) {
+        return utils.isEqual(element, value);
+      });
+      if (!found) {
+        results.push(element);
+      }
+    });
+  }
+  var reply = {documents: {ok: true, values: results}};
+  var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
+  socket.write(replyBuf);
+};

--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var filter = require('../filter');
+var projection = require('../projection');
+var protocol = require('../protocol');
+
+module.exports = function doFind(socket, clientReqMsg) {
+  this.logger.info('doFind');
+  var collection = this.getCollection(clientReqMsg);
+  var query = clientReqMsg.query;
+  var docs;
+  if ('$query' in query) {
+    query = query.$query;
+  }
+  try {
+    if (!projection.validateProjection(clientReqMsg.returnFieldSelector)) {
+      throw new Error(
+        'BadValue Projection cannot have a mix of inclusion and exclusion.');
+    }
+    docs = filter.filterItems(collection, query);
+  } catch (err) {
+    if (err.message.match(/^BadValue /)) {
+      var reply = {documents: [{'$err': err.message}]};
+      var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
+      socket.write(replyBuf);
+      return;
+    } else {
+      throw err;
+    }
+  }
+  var skip = clientReqMsg.numberToSkip;
+  var limit = clientReqMsg.numberToReturn || docs.length;
+  if (limit < 0) {
+    limit = -limit;
+  }
+  docs = docs.slice(skip, skip + limit);
+  docs = projection.getProjection(docs, clientReqMsg.returnFieldSelector);
+  delete this.affectedDocuments;
+  var replyBuf = protocol.toOpReplyBuf(clientReqMsg, { documents: docs });
+  socket.write(replyBuf);
+};

--- a/lib/commands/find_and_modify.js
+++ b/lib/commands/find_and_modify.js
@@ -47,6 +47,7 @@ module.exports = function doFindAndModify(socket, clientReqMsg) {
     function(value, key) {
       return !utils.isOperator(key) && _.contains(key, '.');
     });
+
   if (literalSubfield) {
     writeErrorReply(
       clientReqMsg,

--- a/lib/commands/find_and_modify.js
+++ b/lib/commands/find_and_modify.js
@@ -19,7 +19,7 @@ module.exports = function doFindAndModify(socket, clientReqMsg) {
   this.logger.info('doFindAndModify');
   var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
   var collectionName = clientReqMsg.query.findandmodify;
-  var collection = this.mocks[dbName][collectionName] || [];
+  var collection = this.getCollection(dbName + '.' + collectionName);
   var docs = filter.filterItems(collection, clientReqMsg.query.query);
   var updateKeys = Object.keys(clientReqMsg.query.update || {});
   var firstOperatorIndex = _.findIndex(updateKeys, utils.isOperator);

--- a/lib/commands/find_and_modify.js
+++ b/lib/commands/find_and_modify.js
@@ -1,0 +1,115 @@
+'use strict';
+
+var _ = require('lodash');
+var util = require('util');
+
+var filter = require('../filter');
+var projection = require('../projection');
+var protocol = require('../protocol');
+var update = require('../update');
+var utils = require('../utils');
+
+module.exports = function doFindAndModify(socket, clientReqMsg) {
+  function writeErrorReply(clientReqMsg, errorMessage) {
+    var reply = {documents: [{ok: false, errmsg: errorMessage}]};
+    var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
+    socket.write(replyBuf);
+  }
+
+  this.logger.info('doFindAndModify');
+  var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
+  var collectionName = clientReqMsg.query.findandmodify;
+  var collection = this.mocks[dbName][collectionName] || [];
+  var docs = filter.filterItems(collection, clientReqMsg.query.query);
+  var updateKeys = Object.keys(clientReqMsg.query.update || {});
+  var firstOperatorIndex = _.findIndex(updateKeys, utils.isOperator);
+  var firstNonOperatorIndex = _.findIndex(updateKeys, function(key) {
+    return !utils.isOperator(key);
+  });
+  if (firstOperatorIndex >= 0 && firstNonOperatorIndex >= 0) {
+    var errorMessage;
+    if (firstOperatorIndex < firstNonOperatorIndex) {
+      errorMessage = util.format(
+        "exception: Unknown modifier: %s",
+        updateKeys[firstNonOperatorIndex]);
+    } else {
+      errorMessage = util.format(
+        "exception: The dollar ($) prefixed field '%s' " +
+        "in '%s' is not valid for storage.",
+        updateKeys[firstOperatorIndex],
+        updateKeys[firstOperatorIndex]);
+    }
+    writeErrorReply(clientReqMsg, errorMessage);
+    return;
+  }
+  var literalSubfield = _.findKey(
+    clientReqMsg.query.update,
+    function(value, key) {
+      return !utils.isOperator(key) && _.contains(key, '.');
+    });
+  if (literalSubfield) {
+    writeErrorReply(
+      clientReqMsg,
+      util.format(
+        "exception: The dotted field '%s' in '%s' is not valid for storage.",
+        literalSubfield,
+        literalSubfield));
+    return;
+  }
+  if (!projection.validateProjection(clientReqMsg.query.fields)) {
+    writeErrorReply(
+      clientReqMsg,
+      'exception: You cannot currently mix including and excluding fields. ' +
+      'Contact us if this is an issue.');
+    return;
+  }
+  var returnedDoc = null;
+  if (!clientReqMsg.query.new) {
+    returnedDoc = utils.cloneDocuments(docs[0]);
+  }
+  var upsertedDoc;
+  if (clientReqMsg.query.update) {
+    if (docs.length === 0 && clientReqMsg.query.upsert) {
+      upsertedDoc = {};
+      docs = [upsertedDoc];
+    }
+    update(
+      docs,
+      clientReqMsg.query.query,
+      clientReqMsg.query.update,
+      false,
+      upsertedDoc,
+      this);
+  } else if (clientReqMsg.query.remove) {
+    if (clientReqMsg.query.new) {
+      writeErrorReply(clientReqMsg, "remove and returnNew can't co-exist");
+      return;
+    }
+    if (docs.length > 0) {
+      _.pull(collection, docs[0]);
+    }
+  } else {
+    this.lastError = 'need remove or update';
+  }
+  if (this.lastError) {
+    writeErrorReply(clientReqMsg, this.lastError);
+    delete this.lastError;
+    return;
+  }
+  if (upsertedDoc) {
+    if (!this.mocks[dbName][collectionName]) {
+      this.mocks[dbName][collectionName] = docs;
+    } else {
+      collection.push(upsertedDoc);
+    }
+  }
+  if (clientReqMsg.query.new) {
+    returnedDoc = docs.length > 0 ? docs[0] : null;
+  }
+  returnedDoc = projection.getProjection(
+    [returnedDoc],
+    clientReqMsg.query.fields)[0];
+  var reply = {documents: {value: returnedDoc}};
+  var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
+  socket.write(replyBuf);
+};

--- a/lib/commands/insert.js
+++ b/lib/commands/insert.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function doInsert(socket, clientReqMsg) {
+  this.logger.info('doInsert');
+  var collection = this.getCollection(clientReqMsg);
+  this.affectedDocuments = 0;
+  clientReqMsg.documents.forEach(function(doc) {
+    collection.push(doc);
+    this.affectedDocuments++;
+  }.bind(this));
+};

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var _ = require('lodash');
+var util = require('util');
+
+var filter = require('../filter');
+var update = require('../update');
+var utils = require('../utils');
+
+function keyIsOperator(value, key) {
+  return utils.isOperator(key);
+}
+
+module.exports = function doUpdate(socket, clientReqMsg) {
+  this.logger.info('doUpdate');
+  var collection = this.getCollection(clientReqMsg);
+  var docs = filter.filterItems(collection, clientReqMsg.selector);
+  this.affectedDocuments = 0;
+  var updateContainsOperators = _.any(clientReqMsg.update, keyIsOperator);
+  var updateContainsOnlyOperators = _.every(
+    clientReqMsg.update,
+    keyIsOperator);
+
+  if (clientReqMsg.flags.multiUpdate && !updateContainsOnlyOperators) {
+    this.lastError = 'multi update only works with $ operators';
+    return;
+  }
+
+  var literalSubfield = _.findKey(
+    clientReqMsg.update,
+    function(value, key) {
+      return !utils.isOperator(key) && _.contains(key, '.');
+    });
+  if (literalSubfield) {
+    this.lastError = util.format(
+      "can't have . in field names [%s]",
+      literalSubfield);
+    return;
+  }
+  var upsertedDoc;
+  if (docs.length === 0 && clientReqMsg.flags.upsert) {
+    upsertedDoc = {};
+    collection.push(upsertedDoc);
+    docs = [upsertedDoc];
+  }
+  update(
+    docs,
+    clientReqMsg.selector,
+    clientReqMsg.update,
+    clientReqMsg.flags.multiUpdate,
+    upsertedDoc,
+    this);
+};

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -25,12 +25,12 @@ module.exports = function doUpdate(socket, clientReqMsg) {
     this.lastError = 'multi update only works with $ operators';
     return;
   }
-
   var literalSubfield = _.findKey(
     clientReqMsg.update,
     function(value, key) {
       return !utils.isOperator(key) && _.contains(key, '.');
     });
+
   if (literalSubfield) {
     this.lastError = util.format(
       "can't have . in field names [%s]",

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -7,31 +7,40 @@ var filter = require('./filter');
 var projection = require('./projection');
 var update = require('./update');
 var utils = require('./utils');
-var ElementWrapper = require('./element-wrapper');
 
-var wrapElementForAccess = ElementWrapper.wrapElementForAccess;
-
-var logger;
-
-function getCollection(clientReqMsg) {
-  return eval('that.mocks.' + clientReqMsg.fullCollectionName) || [];
-}
-
-function keyIsOperator(value, key) {
-  return utils.isOperator(key);
-}
+var cmdFind = require('./commands/find');
+var cmdCount = require('./commands/count');
+var cmdInsert = require('./commands/insert');
+var cmdDelete = require('./commands/delete');
+var cmdUpdate = require('./commands/update');
+var cmdFindAndModify = require('./commands/find_and_modify');
+var cmdDistinct = require('./commands/distinct');
 
 that = {
   mocks: null,
 
   init: function(mocks) {
-    logger = require('../lib/log').getLogger('processor');
+    that.logger = require('../lib/log').getLogger('processor');
     that.mocks = mocks;
     filter.init();
   },
 
+  getCollection: function(clientReqMsg) {
+    var fullCollectionName;
+    if (clientReqMsg.fullCollectionName) {
+      fullCollectionName = clientReqMsg.fullCollectionName;
+    } else {
+      fullCollectionName = clientReqMsg;
+    }
+    var match = /([^.]+)[.](.*)/.exec(fullCollectionName);
+    if (match) {
+      return that.mocks[match[1]][match[2]] || [];
+    }
+    return [];
+  },
+
   process: function(socket) {
-    logger.info('New client connection');
+    that.logger.info('New client connection');
     var processSocketData = function(buf) {
       var header, clientReqMsg;
       header = protocol.fromMsgHeaderBuf(buf);
@@ -41,33 +50,37 @@ that = {
           if (clientReqMsg.fullCollectionName.match(/\.\$cmd$/)) {
             if (clientReqMsg.query) {
               if (clientReqMsg.query.findandmodify) {
-                that.doFindAndModify(socket, clientReqMsg);
+                command = that.doFindAndModify;
                 break;
               } else if (clientReqMsg.query.distinct) {
-                that.doDistinct(socket, clientReqMsg);
+                command = that.doDistinct;
+                break;
+              } else if (clientReqMsg.query.count) {
+                command = that.doCount;
                 break;
               }
             }
-            that.doCmdQuery(socket, clientReqMsg);
+            command = that.doCmdQuery;
           } else {
-            that.doQuery(socket, clientReqMsg);
+            command = that.doFind;
           }
           break;
         case protocol.OP_INSERT:
           clientReqMsg = protocol.fromOpInsertBuf(header, buf);
-          that.doInsert(socket, clientReqMsg);
+          command = that.doInsert;
           break;
         case protocol.OP_DELETE:
           clientReqMsg = protocol.fromOpDeleteBuf(header, buf);
-          that.doDelete(socket, clientReqMsg);
+          command = that.doDelete;
           break;
         case protocol.OP_UPDATE:
           clientReqMsg = protocol.fromOpUpdateBuf(header, buf);
-          that.doUpdate(socket, clientReqMsg);
+          command = that.doUpdate;
           break;
         default:
           throw new Error('Operation not supported: ' + header.opCode);
       }
+      command.call(that, socket, clientReqMsg);
       if (buf.bytesRead < buf.length) {
         processSocketData(buf.slice(buf.bytesRead));
       }
@@ -76,17 +89,17 @@ that = {
       try {
         processSocketData(socket);
       } catch (err) {
-        logger.error('Uncaught exception processing socket data: ', err.stack);
+        that.logger.error('Uncaught exception processing socket data: ', err.stack);
       }
     });
     socket.on('end', function() {
-      logger.info('Client connection closed');
+      that.logger.info('Client connection closed');
     });
   },
 
   doCmdQuery: function(socket, clientReqMsg) {
     var reply, replyBuf;
-    logger.debug('doCmdQuery');
+    that.logger.debug('doCmdQuery');
     if (clientReqMsg.query['ismaster']) {
       reply = {
         documents: { 'ismaster': true, 'ok': true }
@@ -104,272 +117,26 @@ that = {
       if ('lastError' in that) {
         reply.documents.ok = false;
         reply.documents.err = that.lastError;
-        logger.debug('Reporting lasterror:', that.lastError);
+        that.logger.debug('Reporting lasterror:', that.lastError);
         delete that.lastError;
       }
       replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
       socket.write(replyBuf);
-    } else if (clientReqMsg.query['count']) {
-      that.doCount(socket, clientReqMsg);
     } else {
-      logger.error('clientReqMsg :', clientReqMsg);
+      that.logger.error('clientReqMsg :', clientReqMsg);
       throw new Error(util.format(
         'Query opeation not supported: %s',
         util.inspect(clientReqMsg.query)));
     }
   },
 
-  doCount: function(socket, clientReqMsg) {
-    logger.info('doCount');
-    var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
-    var collection = that.mocks[dbName][clientReqMsg.query.count];
-    var query = clientReqMsg.query.query;
-    var docs = filter.filterItems(collection, query);
-    var reply = {documents: {ok: true, n: docs.length}};
-    var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
-    socket.write(replyBuf);
-  },
-
-  doQuery: function(socket, clientReqMsg) {
-    var collection, docs, replyBuf;
-    logger.info('doQuery');
-    collection = getCollection(clientReqMsg);
-    var query = clientReqMsg.query;
-    if ('$query' in query) {
-      query = query.$query;
-    }
-    try {
-      if (!projection.validateProjection(clientReqMsg.returnFieldSelector)) {
-        throw new Error(
-          'BadValue Projection cannot have a mix of inclusion and exclusion.');
-      }
-      docs = filter.filterItems(collection, query);
-    } catch (err) {
-      if (err.message.match(/^BadValue /)) {
-        var reply = {documents: [{'$err': err.message}]};
-        var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
-        socket.write(replyBuf);
-        return;
-      } else {
-        throw err;
-      }
-    }
-    var skip = clientReqMsg.numberToSkip;
-    var limit = clientReqMsg.numberToReturn || docs.length;
-    if (limit < 0) {
-      limit = -limit;
-    }
-    docs = docs.slice(skip, skip + limit);
-    docs = projection.getProjection(docs, clientReqMsg.returnFieldSelector);
-    delete that.affectedDocuments;
-    replyBuf = protocol.toOpReplyBuf(clientReqMsg, { documents: docs });
-    socket.write(replyBuf);
-  },
-
-  doInsert: function(socket, clientReqMsg) {
-    var collection;
-    logger.info('doInsert');
-    collection = getCollection(clientReqMsg);
-    that.affectedDocuments = 0;
-    clientReqMsg.documents.forEach(function(doc) {
-      collection.push(doc);
-      that.affectedDocuments++;
-    });
-  },
-
-  doDelete: function(socket, clientReqMsg) {
-    var collection, i, item, key, match;
-    logger.info('doDelete');
-    collection = getCollection(clientReqMsg);
-    that.affectedDocuments = 0;
-    i = 0;
-    var docs = filter.filterItems(collection, clientReqMsg.selector);
-    while (i < collection.length) {
-      item = collection[i];
-      if (docs.indexOf(item) !== -1) {
-        collection.splice(i, 1);
-        that.affectedDocuments++;
-      } else {
-        i++;
-      }
-    }
-  },
-
-  doUpdate: function(socket, clientReqMsg) {
-    logger.info('doUpdate');
-    var collection = getCollection(clientReqMsg);
-    var docs = filter.filterItems(collection, clientReqMsg.selector);
-    that.affectedDocuments = 0;
-    var updateContainsOperators = _.any(clientReqMsg.update, keyIsOperator);
-    var updateContainsOnlyOperators = _.every(
-      clientReqMsg.update,
-      keyIsOperator);
-
-    if (clientReqMsg.flags.multiUpdate && !updateContainsOnlyOperators) {
-      that.lastError = 'multi update only works with $ operators';
-      return;
-    }
-
-    var literalSubfield = _.findKey(
-      clientReqMsg.update,
-      function(value, key) {
-        return !utils.isOperator(key) && _.contains(key, '.');
-      });
-    if (literalSubfield) {
-      that.lastError = util.format(
-        "can't have . in field names [%s]",
-        literalSubfield);
-      return;
-    }
-    var upsertedDoc;
-    if (docs.length === 0 && clientReqMsg.flags.upsert) {
-      upsertedDoc = {};
-      collection.push(upsertedDoc);
-      docs = [upsertedDoc];
-    }
-    update(
-      docs,
-      clientReqMsg.selector,
-      clientReqMsg.update,
-      clientReqMsg.flags.multiUpdate,
-      upsertedDoc,
-      that);
-  },
-
-  doFindAndModify: function(socket, clientReqMsg) {
-    function writeErrorReply(clientReqMsg, errorMessage) {
-      var reply = {documents: [{ok: false, errmsg: errorMessage}]};
-      var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
-      socket.write(replyBuf);
-    }
-
-    logger.info('doFindAndModify');
-    var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
-    var collectionName = clientReqMsg.query.findandmodify;
-    var collection = that.mocks[dbName][collectionName] || [];
-    var docs = filter.filterItems(collection, clientReqMsg.query.query);
-    var updateKeys = Object.keys(clientReqMsg.query.update || {});
-    var firstOperatorIndex = _.findIndex(updateKeys, utils.isOperator);
-    var firstNonOperatorIndex = _.findIndex(updateKeys, function(key) {
-      return !utils.isOperator(key);
-    });
-    if (firstOperatorIndex >= 0 && firstNonOperatorIndex >= 0) {
-      var errorMessage;
-      if (firstOperatorIndex < firstNonOperatorIndex) {
-        errorMessage = util.format(
-          "exception: Unknown modifier: %s",
-          updateKeys[firstNonOperatorIndex]);
-      } else {
-        errorMessage = util.format(
-          "exception: The dollar ($) prefixed field '%s' " +
-          "in '%s' is not valid for storage.",
-          updateKeys[firstOperatorIndex],
-          updateKeys[firstOperatorIndex]);
-      }
-      writeErrorReply(clientReqMsg, errorMessage);
-      return;
-    }
-    var literalSubfield = _.findKey(
-      clientReqMsg.query.update,
-      function(value, key) {
-        return !utils.isOperator(key) && _.contains(key, '.');
-      });
-    if (literalSubfield) {
-      writeErrorReply(
-        clientReqMsg,
-        util.format(
-          "exception: The dotted field '%s' in '%s' is not valid for storage.",
-          literalSubfield,
-          literalSubfield));
-      return;
-    }
-    if (!projection.validateProjection(clientReqMsg.query.fields)) {
-      writeErrorReply(
-        clientReqMsg,
-        'exception: You cannot currently mix including and excluding fields. ' +
-        'Contact us if this is an issue.');
-      return;
-    }
-    var returnedDoc = null;
-    if (!clientReqMsg.query.new) {
-      returnedDoc = utils.cloneDocuments(docs[0]);
-    }
-    var upsertedDoc;
-    if (clientReqMsg.query.update) {
-      if (docs.length === 0 && clientReqMsg.query.upsert) {
-        upsertedDoc = {};
-        docs = [upsertedDoc];
-      }
-      update(
-        docs,
-        clientReqMsg.query.query,
-        clientReqMsg.query.update,
-        false,
-        upsertedDoc,
-        that);
-    } else if (clientReqMsg.query.remove) {
-      if (clientReqMsg.query.new) {
-        writeErrorReply(clientReqMsg, "remove and returnNew can't co-exist");
-        return;
-      }
-      if (docs.length > 0) {
-        _.pull(collection, docs[0]);
-      }
-    } else {
-      that.lastError = 'need remove or update';
-    }
-    if (that.lastError) {
-      writeErrorReply(clientReqMsg, that.lastError);
-      delete that.lastError;
-      return;
-    }
-    if (upsertedDoc) {
-      if (!that.mocks[dbName][collectionName]) {
-        that.mocks[dbName][collectionName] = docs;
-      } else {
-        collection.push(upsertedDoc);
-      }
-    }
-    if (clientReqMsg.query.new) {
-      returnedDoc = docs.length > 0 ? docs[0] : null;
-    }
-    returnedDoc = projection.getProjection(
-      [returnedDoc],
-      clientReqMsg.query.fields)[0];
-    var reply = {documents: {value: returnedDoc}};
-    var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
-    socket.write(replyBuf);
-  },
-
-  doDistinct: function(socket, clientReqMsg) {
-    var key = clientReqMsg.query.key;
-    var query = clientReqMsg.query.query;
-
-    logger.info('doDistinct');
-    var dbName = clientReqMsg.fullCollectionName.replace('.$cmd', '');
-    var collectionName = clientReqMsg.query.distinct;
-    var collection = that.mocks[dbName][collectionName] || [];
-    var docs = filter.filterItems(collection, query);
-
-    var results = [];
-    if (_.isString(key)) {
-      var elements = _(docs).map(function(doc) {
-        return wrapElementForAccess(doc, key).getValue();
-      }).reject(_.isUndefined).value();
-
-      _.forEach(elements, function(element) {
-        var found = _.find(results, function(value) {
-          return utils.isEqual(element, value);
-        });
-        if (!found) {
-          results.push(element);
-        }
-      });
-    }
-    var reply = {documents: {ok: true, values: results}};
-    var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
-    socket.write(replyBuf);
-  }
+  doFind: cmdFind,
+  doCount: cmdCount,
+  doInsert: cmdInsert,
+  doDelete: cmdDelete,
+  doUpdate: cmdUpdate,
+  doFindAndModify: cmdFindAndModify,
+  doDistinct: cmdDistinct
 };
 
 module.exports = that;

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('lodash');
 var util = require('util');
 var net = require('net');
@@ -16,7 +18,7 @@ var cmdUpdate = require('./commands/update');
 var cmdFindAndModify = require('./commands/find_and_modify');
 var cmdDistinct = require('./commands/distinct');
 
-that = {
+var that = {
   mocks: null,
 
   init: function(mocks) {
@@ -42,8 +44,9 @@ that = {
   process: function(socket) {
     that.logger.info('New client connection');
     var processSocketData = function(buf) {
-      var header, clientReqMsg;
-      header = protocol.fromMsgHeaderBuf(buf);
+      var header = protocol.fromMsgHeaderBuf(buf);
+      var clientReqMsg;
+      var command;
       switch (header.opCode) {
         case protocol.OP_QUERY:
           clientReqMsg = protocol.fromOpQueryBuf(header, buf);


### PR DESCRIPTION
@parkr, This moves database operations each into its own module. Next in line: split tests and simplify the API for exchanging information between the processor module and the commands. This will make implementing scaffolding for new commands much easier.