### PR TITLE
Moves tests from testMongoDbFs.js to command tests.

### DIFF
--- a/test/commands/count_test.js
+++ b/test/commands/count_test.js
@@ -29,4 +29,22 @@ describe('count', function() {
       done();
     });
   });
+
+  it('reports count of non-existent collection as zero', function(done) {
+    delete fakeDatabase.items;
+    Item.count({}, function(error, n) {
+      if (error) return done(error);
+      expect(n).to.equal(0);
+      done();
+    });
+  });
+
+  it('does not create a collection if non-existent', function(done) {
+    delete fakeDatabase.items;
+    Item.count({}, function(error, n) {
+      if (error) return done(error);
+      expect(fakeDatabase).to.not.have.property('items');
+      done();
+    });
+  });
 });

--- a/test/commands/distinct_test.js
+++ b/test/commands/distinct_test.js
@@ -77,6 +77,24 @@ describe('distinct', function() {
     });
   });
 
+  it('handles non-existent collection', function(done) {
+    delete fakeDatabase.items;
+    Item.collection.distinct('key', function(error, values) {
+      if (error) return done(error);
+      expect(values).to.deep.equal([]);
+      done();
+    });
+  });
+
+  it('does not create non-existent collection', function(done) {
+    delete fakeDatabase.items;
+    Item.collection.distinct('key', function(error, values) {
+      if (error) return done(error);
+      expect(fakeDatabase).to.not.have.property('items');
+      done();
+    });
+  });
+
   it('returns empty array if field parameter is invalid', function(done) {
     fakeDatabase.items = [{key: 1}, {key: 2}, {key: 3}];
     Item.collection.distinct(42, function(error, values) {

--- a/test/commands/find_and_modify_test.js
+++ b/test/commands/find_and_modify_test.js
@@ -107,6 +107,19 @@ describe('findAndModify', function() {
       });
   });
 
+  it('does not create non-existent collection', function(done) {
+    delete fakeDatabase.items;
+    Item.collection.findAndModify(
+      {b: 1},
+      {},
+      {'$set': {a: 'new value'}},
+      function(error) {
+        if (error) return done(error);
+        expect(fakeDatabase).to.not.have.property('items');
+        done();
+    });
+  });
+
   it('rejects invalid requested projections', function(done) {
     Item.collection.findAndModify(
       {b: 1},
@@ -371,6 +384,22 @@ describe('findAndModify', function() {
             expect(_.omit(item, '_id')).to.deep.equal({a: 'new value'});
             done();
         });
+    });
+
+    it('creates new collection if it does not exist', function(done) {
+      delete fakeDatabase.items;
+      Item.collection.findAndModify(
+        {b: 3},
+        null,
+        {'$set': {a: 'new value'}},
+        {upsert: true},
+        function(error) {
+          if (error) return done(error);
+          expect(fakeDatabase.items).to.have.length(1);
+          expect(_.omit(fakeDatabase.items[0], '_id'))
+            .to.deep.equal({b: 3, a: 'new value'});
+          done();
+      });
     });
   });
 });

--- a/test/commands/find_test.js
+++ b/test/commands/find_test.js
@@ -9,6 +9,7 @@ describe('find', function() {
 
   var id1 = new mongoose.Types.ObjectId();
   var id2 = new mongoose.Types.ObjectId();
+  var id3 = new mongoose.Types.ObjectId();
 
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
@@ -23,6 +24,46 @@ describe('find', function() {
 
   after(function(done) {
     harness.tearDown(done);
+  });
+
+  it('returns all documents', function(done) {
+    fakeDatabase.items = [{key: 'value1'}, {key: 'value2'}];
+    Item.find(function(error, items) {
+      if (error) return done(error);
+      expect(items).to.have.length(2);
+      expect(items[0].toObject()).to.have.property('key', 'value1');
+      expect(items[1].toObject()).to.have.property('key', 'value2');
+      done();
+    });
+  });
+
+  it('returns documents by query', function(done) {
+    fakeDatabase.items = [{key: 'value1'}, {key: 'value2'}];
+    Item.find({key: 'value1'}, function(error, items) {
+      if (error) return done(error);
+      expect(items).to.have.length(1);
+      expect(items[0].toObject()).to.have.property('key', 'value1');
+      done();
+    });
+  });
+
+  it('returns no documents from non-existent collections', function(done) {
+    delete fakeDatabase.items;
+    Item.find({key: 'value1'}, function(error, items) {
+      if (error) return done(error);
+      expect(items).to.have.length(0);
+      expect(fakeDatabase).to.not.have.property('items');
+      done();
+    });
+  });
+
+  it('does not create non-existent collections', function(done) {
+    delete fakeDatabase.items;
+    Item.find({key: 'value1'}, function(error) {
+      if (error) return done(error);
+      expect(fakeDatabase).to.not.have.property('items');
+      done();
+    });
   });
 
   // Verify that the find doesn't hang when issueing the command second time
@@ -42,7 +83,8 @@ describe('find', function() {
   it('supports $query', function(done) {
     fakeDatabase.items = [
       {key: 'value', key2: 2, _id: id2},
-      {key: 'value', key2: 1, _id: id1}];
+      {key: 'value', key2: 1, _id: id1}
+    ];
     Item.collection.find({key: 'value'})
       .sort({key2: 1})  // Calling sort causes MongoDB client to send $query.
       .toArray(function(error, results) {
@@ -65,6 +107,68 @@ describe('find', function() {
         expect(_.omit(results[0], '_id')).to.deep.equal({key2: {a: 'b'}});
         expect(_.omit(results[1], '_id')).to.deep.equal({key2: {a: 'c'}});
         done();
+    });
+  });
+
+  it('supports skip', function(done) {
+    fakeDatabase.items = [
+      {key: 'value1', key2: 1, _id: id1},
+      {key: 'value2', key2: 2, _id: id2},
+      {key: 'value3', key2: 3, _id: id3}
+    ];
+    Item.collection.find({}).skip(1).toArray(function(error, items) {
+      if (error) return done(error);
+      expect(items).to.deep.equal(fakeDatabase.items.slice(1));
+      done();
+    });
+  });
+
+  it('supports limit', function(done) {
+    fakeDatabase.items = [
+      {key: 'value1', key2: 1, _id: id1},
+      {key: 'value2', key2: 2, _id: id2},
+      {key: 'value3', key2: 3, _id: id3}
+    ];
+    Item.collection.find({}).limit(2).toArray(function(error, items) {
+      if (error) return done(error);
+      expect(items).to.deep.equal(fakeDatabase.items.slice(0, 2));
+      done();
+    });
+  });
+
+  it('supports skip together with limit', function(done) {
+    fakeDatabase.items = [
+      {key: 'value1', key2: 1, _id: id1},
+      {key: 'value2', key2: 2, _id: id2},
+      {key: 'value3', key2: 3, _id: id3}
+    ];
+    Item.collection.find({}).skip(1).limit(1).toArray(function(error, items) {
+      if (error) return done(error);
+      expect(items).to.deep.equal(fakeDatabase.items.slice(1, 2));
+      done();
+    });
+  });
+
+  it('supports findById', function(done) {
+    fakeDatabase.items = [
+      {key: 'value1', key2: 1, _id: id1},
+      {key: 'value2', key2: 2, _id: id2},
+      {key: 'value3', key2: 3, _id: id3}
+    ];
+    Item.findById(new mongoose.Types.ObjectId(id3), function(error, item) {
+      if (error) return done(error);
+      expect(item).to.exist();
+      expect(item.toObject()).to.deep.equal(fakeDatabase.items[2]);
+      done();
+    });
+  });
+
+  it('rejects invalid queries', function(done) {
+    Item.collection.find({'$eq': 'value24'}).toArray(function(error) {
+      expect(error)
+        .to.have.property('message')
+        .to.match(/BadValue unknown top level operator: [$]eq/);
+      done();
     });
   });
 

--- a/test/commands/insert_test.js
+++ b/test/commands/insert_test.js
@@ -21,8 +21,19 @@ describe('insert', function() {
     harness.tearDown(done);
   });
 
-  it('basic', function(done) {
+  it('adds documents to collection', function(done) {
     fakeDatabase.items = [];
+    Item.collection.insert({key: 'value'}, function(error) {
+      if (error) return done(error);
+      expect(fakeDatabase.items).to.have.length(1);
+      expect(fakeDatabase.items[0])
+        .to.have.property('key', 'value');
+      done();
+    });
+  });
+
+  it('creates collection if it does not exist', function(done) {
+    delete fakeDatabase.items;
     Item.collection.insert({key: 'value'}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase.items).to.have.length(1);

--- a/test/commands/remove_test.js
+++ b/test/commands/remove_test.js
@@ -32,13 +32,22 @@ describe('remove', function() {
     });
   });
 
-  it('by query', function(done) {
+  it('removes documents by query', function(done) {
     fakeDatabase.items = [{key: 'value1'}, {key: 'value2'}];
     Item.remove({key: {$ne: 'value1'}}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase.items).to.have.length(1);
       expect(fakeDatabase.items[0])
         .to.have.property('key', 'value1');
+      done();
+    });
+  });
+
+  it('does not create non-existent collection', function(done) {
+    delete fakeDatabase.items;
+    Item.remove({key: 'value1'}, function(error) {
+      if (error) return done(error);
+      expect(fakeDatabase).to.not.have.property('items');
       done();
     });
   });

--- a/test/testMongoDbFs.js
+++ b/test/testMongoDbFs.js
@@ -8,63 +8,28 @@ var util = require('util');
 
 var TestHarness = require('./test_harness');
 
+var ObjectId = mongoose.Types.ObjectId;
+
 var Item;
-var NonExistent;
 
-var mocks = {
-  fakedb: {
-    items: [
-      {
-        _id: new mongoose.Types.ObjectId(),
-        field1: 'value1',
-        field2: {
-          field3: 31,
-          field4: 'value4'
-        },
-        field5: ['a', 'b', 'c']
-      },
-      {
-        _id: new mongoose.Types.ObjectId(),
-        field1: 'value11',
-        field2: {
-          field3: 32,
-          field4: 'value14'
-        },
-        field5: ['a', 'b', 'd']
-      },
-      {
-        _id: new mongoose.Types.ObjectId(),
-        field1: 'value21',
-        field2: {
-          field3: 33,
-          field4: 'value24'
-        },
-        field5: ['a', 'e', 'f']
-      }
-    ]
-  }
-};
+var fakeDatabase = {
+  items: [
+    {key: 1, _id: new ObjectId()},
+    {key: 2, compound: {subkey: 21}, _id: new ObjectId()},
+    {key: 3, compound: {subkey: 31}, _id: new ObjectId()}
+  ]
+}
 
-describe('MongoDB-Fs', function() {
+describe('Works in forked mode', function() {
   var expect = chai.expect;
-  var harness = new TestHarness(mocks);
+  var harness = new TestHarness({fakedb: fakeDatabase});
 
   before(function(done) {
     harness.config.fork = true;
     harness.setUp(function(error) {
       if (error) return done(error);
-
-      var itemSchema = {
-        field1: String,
-        field2: {
-          field3: Number,
-          field4: String
-        },
-        field5: Array
-      };
       delete mongoose.connection.models.Item;
-      Item = mongoose.model('Item', itemSchema);
-      NonExistent = mongoose.model('NonExistent', { name: String });
+      Item = mongoose.model('Item', {key: Number, compound: {subkey: Number}});
       done();
     });
   });
@@ -80,142 +45,7 @@ describe('MongoDB-Fs', function() {
       if (error) return done(error);
       // Use copies of the original mock objects to avoid one test affecting
       // others by modifying objects in the database.
-      var itemsCopy = _.cloneDeep(mocks.fakedb.items, function(value) {
-        if (value instanceof mongoose.Types.ObjectId) {
-          return new mongoose.Types.ObjectId(value.toString());
-        } else {
-          return undefined;
-        }
-      });
-      Item.collection.insert(itemsCopy, done);
-    });
-  });
-
-  describe('filters', function() {
-    it('$all', function(done) {
-      Item.find({'field5': {$all: ['a', 'c']}}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(1);
-        expect(items[0].toObject())
-          .to.have.property('field5')
-          .that.is.deep.equal(['a', 'b', 'c']);
-        done();
-      });
-    });
-
-    it('$gt', function(done) {
-      Item.find({'field2.field3': {$gt: 32}}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(1);
-        expect(items[0].toObject())
-          .to.have.deep.property('field2.field3', 33);
-        done();
-      });
-    });
-
-    it('$gte', function(done) {
-      Item.find({'field2.field3': {$gte: 32}}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(2);
-        done();
-      });
-    });
-
-    it('$in', function(done) {
-      Item.find({'field2.field3': {$in: [32, 33]}}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(2);
-        expect(items[0]).to.have.deep.property('field2.field3', 32);
-        expect(items[1]).to.have.deep.property('field2.field3', 33);
-        done();
-      });
-    });
-
-    it('$lt', function(done) {
-      Item.find({'field2.field3': { $lt: 32}}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(1);
-        expect(items[0]).to.have.deep.property('field2.field3', 31);
-        done();
-      });
-    });
-
-    it('$lte', function(done) {
-      Item.find({'field2.field3': {$gte: 32}}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(2);
-        done();
-      });
-    });
-
-    it('$ne', function(done) {
-      Item.find({'field2.field3': {$ne: 32}}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(2);
-        expect(items[0]).to.have.deep.property('field2.field3', 31);
-        expect(items[1]).to.have.deep.property('field2.field3', 33);
-        done();
-      });
-    });
-
-    it('$nin', function(done) {
-      Item.find({'field2.field3': {$nin: [32, 33]}}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(1);
-        expect(items[0]).to.have.deep.property('field2.field3', 31);
-        done();
-      });
-    });
-
-    it('$or', function(done) {
-      Item.find({$or: [
-        {field1: 'value1'},
-        {'field2.field3': 32}
-      ]}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(2);
-        expect(items[0]).to.have.property('field1', 'value1');
-        expect(items[0]).to.have.deep.property('field2.field3', 31);
-        expect(items[1]).to.have.property('field1', 'value11');
-        expect(items[1]).to.have.deep.property('field2.field3', 32);
-        done();
-      });
-    });
-
-    it('simple filter', function(done) {
-      Item.find({'field2.field3': 32}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(1);
-        expect(items[0]).to.have.deep.property('field2.field3', 32);
-        done();
-      });
-    });
-
-    it('2 fields filter', function(done) {
-      Item.find({field1: 'value1', 'field2.field3': 31}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(1);
-        expect(items[0]).to.have.property('field1', 'value1');
-        expect(items[0]).to.have.deep.property('field2.field3', 31);
-        done();
-      });
-    });
-
-    it('string filter', function(done) {
-      Item.find({'field2.field4': 'value24'}, function(error, items) {
-        if (error) return done(error);
-        expect(items).to.have.length(1);
-        expect(items[0]).to.have.deep.property('field2.field4', 'value24');
-        done();
-      });
-    });
-
-    it('reports invalid queries', function(done) {
-      Item.find({'$eq': 'value24'}, function(error, items) {
-        expect(error).to.match(/BadValue unknown top level operator: [$]eq/);
-        expect(items).to.not.exist;
-        done();
-      });
+      Item.collection.insert(fakeDatabase.items, done);
     });
   });
 
@@ -223,108 +53,43 @@ describe('MongoDB-Fs', function() {
     it('finds all documents', function(done) {
       Item.find(function(error, items) {
         if (error) return done(error);
-        expect(items).to.have.length(3);
+        expect(_.pluck(items, 'key')).to.deep.equal([1, 2, 3]);
         done();
       });
     });
 
-    it('finds no unknown documents', function(done) {
-      NonExistent.find(function(error, items) {
+    it('finds documents by query', function(done) {
+      Item.find({key: {'$gt': 1}}, function(error, items) {
         if (error) return done(error);
-        expect(items).to.have.length(0);
+        expect(_.pluck(items, 'key')).to.deep.equal([2, 3]);
         done();
       });
     });
+  });
 
-    it('supports skip', function(done) {
-      Item.find({}).skip(1).exec(function(error, items) {
-        if (error) return done(error);
-        expect(_.pluck(items, 'field1')).to.deep.equal(['value11', 'value21']);
-        done();
-      });
-    });
-
-    it('supports limit', function(done) {
-      Item.find({}).limit(2).exec(function(error, items) {
-        if (error) return done(error);
-        expect(_.pluck(items, 'field1')).to.deep.equal(['value1', 'value11']);
-        done();
-      });
-    });
-
-    it('supports skip together with limit', function(done) {
-      Item.find({}).skip(1).limit(1).exec(function(error, items) {
-        if (error) return done(error);
-        expect(_.pluck(items, 'field1')).to.deep.equal(['value11']);
-        done();
-      });
-    });
-
-    it('findById', function(done) {
-      Item.findOne({field1: 'value1'}, function(error, item) {
-        if (error) return done(error);
-        expect(item).to.have.property('id');
-        var itemId = item.id;
-        Item.findById(itemId, function(error, item) {
+  describe('findAndUpdate', function(done) {
+    it('basic', function(done) {
+      Item.findByIdAndUpdate(
+        {_id: fakeDatabase.items[1]._id},
+        {'$set': {key: 18}},
+        function(error, item) {
           if (error) return done(error);
-          expect(item).to.not.be.empty;
+          expect(item).to.have.property('key', 18);
           done();
-        });
-      });
-    });
-
-    it('findByIdAndUpdate', function(done) {
-      Item.findOne({field1: 'value1'}, function(error, item) {
-        if (error) return done(error);
-        expect(item).to.have.property('id');
-        var itemId = item.id;
-        Item.findByIdAndUpdate(
-          itemId,
-          {'$set': {field1: 'value1Modified'}},
-          function(error, item) {
-            if (error) return done(error);
-            expect(item).to.have.property('field1', 'value1Modified');
-            done();
-        });
       });
     });
   });
 
   describe('insert', function() {
-    var newItemFields = {
-      field1: 'value101',
-      field2: {
-        field3: 1031,
-        field4: 'value104'},
-      field5: ['h', 'i', 'j']};
-
     it('saves document to collection', function(done) {
-      var item = new Item(newItemFields);
+      var item = new Item({key: 4});
       item.save(function(error, savedItem) {
         if (error) return done(error);
-        expect(savedItem).to.exist;
+        expect(savedItem).to.exist();
         Item.findById(savedItem._id, function(error, newItem) {
         if (error) return done(error);
           expect(newItem).to.exist;
-          expect(newItem.toObject())
-            .to.deep.equal(savedItem.toObject());
-          Item.collection.count({}, function(error, count) {
-            if (error) return done(error);
-            expect(count).to.equal(mocks.fakedb.items.length + 1);
-            done();
-          });
-        });
-      });
-    });
-
-    it('changes document count', function(done) {
-      var item = new Item(newItemFields);
-      item.save(function(error, savedItem) {
-        if (error) return done(error);
-        expect(savedItem).to.exist;
-        Item.collection.count({}, function(error, count) {
-          if (error) return done(error);
-          expect(count).to.equal(mocks.fakedb.items.length + 1);
+          expect(newItem.toObject()).to.deep.equal(savedItem.toObject());
           done();
         });
       });
@@ -333,9 +98,9 @@ describe('MongoDB-Fs', function() {
 
   describe('remove', function() {
     it('removes document from collection', function(done) {
-      Item.findOne({'field1': 'value11'}, function(error, item) {
+      Item.findOne({'key': 2}, function(error, item) {
         if (error) return done(error);
-        expect(item).to.exist;
+        expect(item).to.exist();
         item.remove(function(error) {
           if (error) return done(error);
           Item.findById(item._id, function(error, noItem) {
@@ -346,105 +111,24 @@ describe('MongoDB-Fs', function() {
         });
       });
     });
-
-    it('changes documents count', function(done) {
-      Item.findOne({'field1': 'value11'}, function(error, item) {
-        if (error) return done(error);
-        expect(item).to.exist;
-        item.remove(function(error) {
-          Item.collection.count({}, function(error, count) {
-            if (error) return done(error);
-            expect(count).to.equal(mocks.fakedb.items.length - 1);
-            done();
-          });
-        });
-      });
-    });
-
-    it('removes documents by query', function(done) {
-      Item.remove({'field2.field3': {$gt: 31}}, function(error, numAffected) {
-        if (error) return done(error);
-        expect(numAffected).to.equal(2);
-        Item.find({}, function(error, items) {
-        if (error) return done(error);
-          expect(items).to.have.length(1);
-          expect(items[0].toObject())
-            .to.deep.equal(mocks.fakedb.items[0]);
-          done();
-        });
-      });
-    });
   });
 
   describe('update', function() {
-    it('updates top-level fields', function(done) {
-      Item.findOne({'field1': 'value11'}, function(error, item) {
+    it('updates documents', function(done) {
+      Item.findOne({key: 1}, function(error, item) {
         if (error) return done(error);
-        expect(item).to.exist;
-        item.field1 = 'new value';
+        expect(item).to.exist();
+        item.key = 42;
         item.save(function(error) {
           if (error) return done(error);
           Item.findById(item._id, function(error, newItem) {
             if (error) return done(error);
-            expect(newItem).to.exist;
+            expect(newItem).to.exist();
             expect(newItem.toObject()).to.deep.equal(item.toObject());
             done();
           });
         });
       });
-    });
-
-    it('does not change document count', function(done) {
-      Item.findOne({}, function(error, item) {
-        if (error) return done(error);
-        expect(item).to.exist;
-        item.field1 = 'new value';
-        item.save(function(error) {
-          Item.collection.count({}, function(error, count) {
-            if (error) return done(error);
-            expect(count).to.equal(mocks.fakedb.items.length);
-            done();
-          });
-        });
-      });
-    });
-
-    it('updates fields in subdocuments', function(done) {
-      Item.findOne({'field1': 'value11'}, function(error, item) {
-        if (error) return done(error);
-        expect(item).to.have.deep.property('field2.field3');
-        item.field2.field3 = 424242;
-        item.save(function(error) {
-          if (error) return done(error);
-          Item.findById(item._id, function(error, newItem) {
-            if (error) return done(error);
-            expect(newItem).to.exist;
-            expect(newItem.toObject()).to.deep.equal(item.toObject());
-            done();
-          });
-        });
-      });
-    });
-
-    it('updates documents by query', function(done) {
-      Item.update(
-        {'field2.field3': {$gt: 31}},
-        {$set: {field1: 'new value'}},
-        {multi: true},
-        function(error, numAffected) {
-          if (error) return done(error);
-          expect(numAffected).to.equal(2);
-          Item.find({}, function(error, items) {
-            if (error) return done(error);
-            expect(items)
-              .to.have.deep.property('[0].field1', 'value1');
-            expect(items)
-              .to.have.deep.property('[1].field1', 'new value');
-            expect(items)
-              .to.have.deep.property('[2].field1', 'new value');
-            done();
-          });
-        });
     });
   });
 });


### PR DESCRIPTION
@parkr, This change

* moves many unique tests from `testMongoDbFs.js` to command-specific tests and deletes more tests that just duplicate tests in other places (that includes filter tests; filters are extensively tested in `testFilterItems.js`).
* adds more tests related to creation of non-existent collections by different commands
* removes `test/mocks.js`

All this leaves `testMongoDbFs.js` with just a handful of tests to verify forked mode. I am planning to rename it in another PR to reflect that.