### PR TITLE
Adds experimental command-line server.

### DIFF
--- a/bin/test-server.js
+++ b/bin/test-server.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var util = require('util');
+
+var mongodbFs = require('../lib/mongodb-fs');
+
+var port = 27027;
+var database = 'fakedb';
+
+var config = {
+  port: port,
+  mocks: {},
+  log: {level: process.env.LOG_LEVEL}
+};
+config[database] = {};
+
+mongodbFs.init(config);
+
+mongodbFs.start(function(error) {
+  if (error) {
+    console.error('Failed to start:', error.message);
+  } else {
+    console.info('Server started, awaiting connections.');
+    console.info(util.format(
+      "Run 'mongo localhost:%d/%s' to connect.",
+      port,
+      database)); 
+    console.info('Press Ctrl+C to stop.');
+  }
+});

--- a/lib/commands/query_command.js
+++ b/lib/commands/query_command.js
@@ -13,7 +13,7 @@ BaseCommand.setUpCommand(QueryCommand, undefined);
 
 QueryCommand.prototype.handle = function(clientReqMsg) {
   this.logger.debug('doCmdQuery');
-  if (clientReqMsg.query.isMaster) {
+  if (clientReqMsg.query.isMaster || clientReqMsg.query.ismaster) {
     return {documents: {ismaster: true, ok: true}};
   } else if (clientReqMsg.query.getlasterror) {
     return this.server.lastReply;

--- a/lib/commands/query_command.js
+++ b/lib/commands/query_command.js
@@ -13,10 +13,26 @@ BaseCommand.setUpCommand(QueryCommand, undefined);
 
 QueryCommand.prototype.handle = function(clientReqMsg) {
   this.logger.debug('doCmdQuery');
-  if (clientReqMsg.query.ismaster) {
+  if (clientReqMsg.query.isMaster) {
     return {documents: {ismaster: true, ok: true}};
   } else if (clientReqMsg.query.getlasterror) {
     return this.server.lastReply;
+  } else if (clientReqMsg.query.whatsmyuri) {
+    // This is an internal MongDB command used by the mongo command line
+    // client.
+    var socket = this.server.socket;
+    var format = socket.remoteFamily === 'IPv6' ? '[%s]:%d' : '%s:%d';
+    var hostPort = util.format(format, socket.remoteAddress, socket.remotePort);
+
+    return {documents: {you: hostPort, ok: 1}};
+  } else if (clientReqMsg.query.getLog) {
+    // This is an internal MongDB command used by the mongo command line
+    // client.
+    return {documents: {totalLinesWritten: 0, log: [], ok: 1}};
+  } else if (clientReqMsg.query.replSetGetStatus) {
+    // This is an internal MongDB command used by the mongo command line
+    // client.
+    return {documents: {ok: 0, errmsg: 'not supported'}};
   } else {
     this.logger.error('clientReqMsg :', clientReqMsg);
     throw new Error(util.format(

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -6,6 +6,7 @@ var net = require('net');
 
 var protocol = require('./protocol');
 var filter = require('./filter');
+var log = require('./log');
 var projection = require('./projection');
 var update = require('./update');
 var utils = require('./utils');
@@ -19,97 +20,144 @@ var Insert = require('./commands/insert');
 var QueryCommand = require('./commands/query_command');
 var Update = require('./commands/update');
 
-var that = {
-  mocks: null,
+// Retirns a copy of clientReqMsg edited for debug output.
+function debugFormat(clientReqMsg) {
+  var result = _.cloneDeep(clientReqMsg);
+  var format;
+  switch (result.header.opCode) {
+    case protocol.OP_QUERY:
+      format = 'OP_QUERY (%d)';
+      break;
+    case protocol.OP_INSERT:
+      format = 'OP_INSERT (%d)';
+      break;
+    case protocol.OP_DELETE:
+      format = 'OP_DELETE (%d)';
+      break;
+    case protocol.OP_UPDATE:
+      format = 'OP_UPDATE (%d)';
+      break;
+    default:
+      format = '%d';
+  }
+  result.opCode = util.format(format, result.header.opCode);
+  delete result.header;
+  result.flags = _.pick(result.flags, _.identity);
+  if (Object.keys(result.flags).length === 0) {
+    delete result.flags;
+  }
+  if (!result.numberToSkip) {
+    delete result.numberToSkip;
+  }
+  if (!result.returnFieldSelector) {
+    delete result.returnFieldSelector;
+  }
+  return result;
+}
 
-  init: function(mocks) {
-    that.logger = require('../lib/log').getLogger('processor');
-    that.mocks = mocks;
-    filter.init();
-  },
+function Processor(socket, logger) {
+  this.socket = socket;
+  this.logger = logger;
 
-  getCollection: function(databaseName, collectionName) {
-    return that.mocks[databaseName][collectionName] || [];
-  },
-
-  ensureCollection: function(databaseName, collectionName, collection) {
-    var database = this.mocks[databaseName];
-    if (!database[collectionName]) {
-      database[collectionName] = collection;
-    } else if (database[collectionName] !== collection) {
-      throw new Error(util.format(
-        'Attempt to replace collection %s.%s',
-        databaseName,
-        collectionName));
+  socket.on('data', function(buffer) {
+    try {
+      this.processSocketData(buffer);
+    } catch (error) {
+      this.logger.error(
+        'Uncaught exception processing socket data: ',
+        error.stack);
     }
-  },
+  }.bind(this));
 
-  process: function(socket) {
-    that.logger.info('New client connection');
-    var processSocketData = function(buf) {
-      var header = protocol.fromMsgHeaderBuf(buf);
-      var clientReqMsg;
-      var Command;
-      switch (header.opCode) {
-        case protocol.OP_QUERY:
-          clientReqMsg = protocol.fromOpQueryBuf(header, buf);
-          if (clientReqMsg.fullCollectionName.match(/\.\$cmd$/)) {
-            if (clientReqMsg.query) {
-              if (clientReqMsg.query.findandmodify) {
-                Command = FindAndModify;
-                break;
-              } else if (clientReqMsg.query.distinct) {
-                Command = Distinct;
-                break;
-              } else if (clientReqMsg.query.count) {
-                Command = Count;
-                break;
-              }
-            }
-            Command = QueryCommand;
-          } else {
-            Command = Find;
+  socket.on('end', function() {
+    this.logger.info('Client connection closed');
+  }.bind(this));
+}
+
+Processor.init = function init(mocks) {
+  Processor._logger = log.getLogger('processor');
+  Processor._mocks = mocks;
+  filter.init();
+};
+
+Processor.prototype.getCollection = function getCollection(
+  databaseName,
+  collectionName) {
+  return Processor._mocks[databaseName][collectionName] || [];
+};
+
+Processor.prototype.ensureCollection = function ensureCollection(
+  databaseName,
+  collectionName,
+  collection) {
+  var database = Processor._mocks[databaseName];
+  if (!database[collectionName]) {
+    database[collectionName] = collection;
+  } else if (database[collectionName] !== collection) {
+    throw new Error(util.format(
+      'Attempt to replace collection %s.%s',
+      databaseName,
+      collectionName));
+  }
+}
+
+Processor.process = function onNewConnection(socket) {
+  new Processor(socket, Processor._logger);
+}
+
+Processor.prototype.processSocketData = function processSocketData(buf) {
+  var header = protocol.fromMsgHeaderBuf(buf);
+  var clientReqMsg;
+  var Command;
+  switch (header.opCode) {
+    case protocol.OP_QUERY:
+      clientReqMsg = protocol.fromOpQueryBuf(header, buf);
+      if (clientReqMsg.fullCollectionName.match(/\.\$cmd$/)) {
+        if (clientReqMsg.query) {
+          if (clientReqMsg.query.findandmodify) {
+            Command = FindAndModify;
+            break;
+          } else if (clientReqMsg.query.distinct) {
+            Command = Distinct;
+            break;
+          } else if (clientReqMsg.query.count) {
+            Command = Count;
+            break;
           }
-          break;
-        case protocol.OP_INSERT:
-          clientReqMsg = protocol.fromOpInsertBuf(header, buf);
-          Command = Insert;
-          break;
-        case protocol.OP_DELETE:
-          clientReqMsg = protocol.fromOpDeleteBuf(header, buf);
-          Command = Delete;
-          break;
-        case protocol.OP_UPDATE:
-          clientReqMsg = protocol.fromOpUpdateBuf(header, buf);
-          Command = Update;
-          break;
-        default:
-          throw new Error('Operation not supported: ' + header.opCode);
-      }
-      var command = new Command(that);
-      var reply = command.handle(clientReqMsg);
-
-      if (header.opCode === protocol.OP_QUERY) {
-        var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
-        socket.write(replyBuf);
+        }
+        Command = QueryCommand;
       } else {
-        that.lastReply = reply;
+        Command = Find;
       }
-      if (buf.bytesRead < buf.length) {
-        processSocketData(buf.slice(buf.bytesRead));
-      }
-    };
-    socket.on('data', function(socket) {
-      try {
-        processSocketData(socket);
-      } catch (err) {
-        that.logger.error('Uncaught exception processing socket data: ', err.stack);
-      }
-    });
-    socket.on('end', function() {
-      that.logger.info('Client connection closed');
-    });
+      break;
+    case protocol.OP_INSERT:
+      clientReqMsg = protocol.fromOpInsertBuf(header, buf);
+      Command = Insert;
+      break;
+    case protocol.OP_DELETE:
+      clientReqMsg = protocol.fromOpDeleteBuf(header, buf);
+      Command = Delete;
+      break;
+    case protocol.OP_UPDATE:
+      clientReqMsg = protocol.fromOpUpdateBuf(header, buf);
+      Command = Update;
+      break;
+    default:
+      throw new Error('Operation not supported: ' + header.opCode);
+  }
+  var command = new Command(this);
+  this.logger.debug('Received client request:', debugFormat(clientReqMsg));
+  var reply = command.handle(clientReqMsg);
+
+  if (header.opCode === protocol.OP_QUERY) {
+    var replyBuf = protocol.toOpReplyBuf(clientReqMsg, reply);
+    this.socket.write(replyBuf);
+  } else {
+    this.lastReply = reply;
+  }
+  if (buf.bytesRead < buf.length) {
+    this.processSocketData(buf.slice(buf.bytesRead));
   }
 };
 
-module.exports = that;
+module.exports = Processor;


### PR DESCRIPTION
@parkr @rodaine

This change does the following:
* Re-factors processor to be an object and use separate instance for every network connection. This avoids problems with keeping a single state (e.g., `lastReply` for multiple connections). Also gives each instance access to its network socket.
* Implements several internal MongoDB commands necessary for supporting interactions with the `mongo` command line client.
* Implements a test server which can talk to the `mongo` command line client. Its value is in being able to report format of various commands `mongo` sends it, which will help with implementing those commands.