### PR TITLE
Implements multiple server instances.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,7 +6,7 @@ var plugins      = require('gulp-load-plugins')();
 var SRC = {
   LIB:   ['lib/**/*.js'],
   TESTS: ['test/**/*.js', 'test/*.js'],
-  BIN:   ['bin/**/*.js']
+  BIN:   ['bin/*.js']
 };
 
 gulp.task('lint', function() {

--- a/bin/test-server.js
+++ b/bin/test-server.js
@@ -20,7 +20,7 @@ mongodbFs.start(function(error) {
   if (error) {
     process.stderr.write('Failed to start:' + error.message + '\n');
   } else {
-    process.stdout.write('Server started, awaiting connections.\n');
+    process.stdout.write('Server started, awaiting connections...\n');
     process.stdout.write(util.format(
       "Run 'mongo localhost:%d/%s' to connect.\n",
       port,

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -403,10 +403,10 @@ function evaluateComparerInContext(context, comparer, value) {
 }
 
 module.exports = {
-  init: function() {
-    logger = log.getLogger('filter');
-  },
   filterItems: function(documents, selector) {
+    if (!logger) {
+      logger = log.getLogger('filter');
+    }
     if (!selector || utils.isEmpty(selector)) {
       return documents;
     }

--- a/lib/mongodb-fs.js
+++ b/lib/mongodb-fs.js
@@ -5,99 +5,107 @@ var childProcess = require('child_process');
 var net = require('net');
 
 var log = require('./log');
-var processor = require('./processor');
+var Processor = require('./processor');
 var utils = require('./utils');
 
-var that = {
-  server: null,
-  running: false,
-  child: null,
-  logger: null,
+function Server(config) {
+  this.server = null;
+  this.running = false;
+  this.child = null;
+  this.config = _.extend({port: 27017, fork: false}, config);
 
-  init: function(config) {
-    that.config = _.extend({port: 27017, fork: false}, config);
+  var logConfig = this.config.log;
 
-    var logConfig = that.config.log;
-
-    if (logConfig) {
-      if (that.config.fork && logConfig.logger) {
-        // Cannot pass active object into forked process directly, just use its
-        // log level if available.
-        logConfig.logLevel = logConfig.logger.level || logConfig.logLevel;
-        delete logConfig.logger;
-      } else if (logConfig.logger && !logConfig.logger.trace) {
-        // Our code logs using the `trace` method.  If it's not present on the
-        // the provided logger, extend it with the method stubbed.
-        logConfig.logger = Object.create(
-          logConfig.logger,
-          {trace: {value: function() {}}});
-      }
+  if (logConfig) {
+    if (this.config.fork && logConfig.logger) {
+      // Cannot pass active object into forked process directly, just use its
+      // log level if available.
+      logConfig.logLevel = logConfig.logger.level || logConfig.logLevel;
+      delete logConfig.logger;
+    } else if (logConfig.logger && !logConfig.logger.trace) {
+      // Our code logs using the `trace` method.  If it's not present on the
+      // the provided logger, extend it with the method stubbed.
+      logConfig.logger = Object.create(
+        logConfig.logger,
+        {trace: {value: function() {}}});
     }
-    log.init(that.config.log);
-    that.logger = log.getLogger('main');
-    processor.init(that.config.mocks);
-  },
-
-  start: function(callback) {
-    callback = utils.safeCallback(callback);
-
-    if (that.config.fork) {
-      that.child = childProcess.fork(__filename);
-      that.child.send({ action: 'start', config: that.config });
-      that.child.on('message', function(data) {
-        if (data.state === 'started') {
-          callback(data.err);
-        }
-      });
-      return;
-    }
-    that.logger.info('Starting server');
-    that.server = net.createServer(processor.process);
-    that.server.listen(that.config.port, function(err) {
-      that.logger.info('Server ready, listening to port ', that.config.port);
-      that.running = true;
-      callback(err);
-    });
-  },
-
-  stop: function(callback) {
-    callback = utils.safeCallback(callback);
-
-    if (that.child) {
-      that.child.send({ action: 'stop' });
-      that.child.on('message', function(data) {
-        if (data.state === 'stopped') {
-          callback(data.err);
-        }
-        that.child = null;
-      });
-      return;
-    }
-    that.logger.info('Stopping server');
-    that.server.close(function() {
-      that.logger.info('Server stopped');
-      that.running = false;
-      callback();
-    });
-  },
-
-  isRunning: function() {
-    return that.running || that.child;
   }
+  log.init(this.config.log);
+
+  this.logger = log.getLogger('main');
+  this.processor = new Processor(this.config.mocks);
+}
+
+Server.prototype.start = function start(callback) {
+  callback = utils.safeCallback(callback);
+
+  if (this.config.fork) {
+    this.child = childProcess.fork(__filename);
+    this.child.send({ action: 'start', config: this.config });
+    this.child.on('message', function(data) {
+      if (data.state === 'started') {
+        callback(data.err);
+      }
+    });
+    return;
+  }
+  this.logger.info('Starting server');
+  this.server = net.createServer(this.processor.process.bind(this.processor));
+  this.server.listen(this.config.port, function(error) {
+    if (!error) {
+      this.logger.info('Server ready, listening to port ', this.config.port);
+      this.running = true;
+    }
+    callback(error);
+  }.bind(this));
+};
+
+Server.prototype.stop = function stop(callback) {
+  callback = utils.safeCallback(callback);
+
+  if (this.child) {
+    this.child.send({ action: 'stop' });
+    this.child.on('message', function(data) {
+      if (data.state === 'stopped') {
+        callback(data.err);
+      }
+      this.child = null;
+    }.bind(this));
+    return;
+  }
+  this.logger.info('Stopping server');
+  this.server.close(function() {
+    this.logger.info('Server stopped');
+    this.running = false;
+    callback();
+  }.bind(this));
+};
+
+Server.prototype.isRunning = function isRunning() {
+  return this.running || this.child;
+};
+
+Server.init = function init(config) {
+  Server._defaultInstance = new Server(config);
+  Server.start = Server._defaultInstance.start.bind(Server._defaultInstance);
+  Server.stop = Server._defaultInstance.stop.bind(Server._defaultInstance);
+  Server.isRunning = Server._defaultInstance.isRunning.bind(
+    Server._defaultInstance);
 };
 
 if (module.parent) {
-  module.exports = that;
+  module.exports = Server;
 } else {
+  var server;
   process.on('message', function handleParentMessage(data) {
     if (data.action === 'start') {
       data.config.fork = false;
-      that.init(data.config);
-      that.start(function(err) {
+      server = new Server(data.config);
+      server.start(function(err) {
         process.send({state: 'started', err: err});
       });
     } else if (data.action === 'stop') {
-      that.stop(function(err) {
+      server.stop(function(err) {
         process.send({state: 'stopped', err: err});
         process.removeListener('message', handleParentMessage);
       });

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var _ = require('lodash');
+var events = require('events');
 var util = require('util');
 
 var protocol = require('./protocol');
-var filter = require('./filter');
 var log = require('./log');
 
 var CreateIndexes = require('./commands/create_indexes');
@@ -52,7 +52,8 @@ function debugFormat(clientReqMsg) {
   return util.inspect(result, {depth: 5});
 }
 
-function Processor(socket, logger) {
+function ServerConnection(mocks, socket, logger) {
+  this._mocks = mocks;
   this.socket = socket;
   this.logger = logger;
 
@@ -68,35 +69,28 @@ function Processor(socket, logger) {
 
   socket.on('end', function() {
     this.logger.info('Client connection closed');
-    _.pull(Processor._connections, this);
+    this.emit('end');
   }.bind(this));
 }
+util.inherits(ServerConnection, events.EventEmitter);
 
-Processor._connections = [];
-
-Processor.init = function init(mocks) {
-  Processor._logger = log.getLogger('processor');
-  Processor._mocks = mocks;
-  filter.init();
-};
-
-Processor.prototype.getCollection = function getCollection(
+ServerConnection.prototype.getCollection = function getCollection(
   databaseName,
   collectionName) {
-  return Processor._mocks[databaseName][collectionName] || [];
+  return this._mocks[databaseName][collectionName] || [];
 };
 
-Processor.prototype.collectionExists = function collectionExists(
+ServerConnection.prototype.collectionExists = function collectionExists(
     databaseName,
     collectionName) {
-  return !!(Processor._mocks[databaseName] || {})[collectionName];
+  return !!(this._mocks[databaseName] || {})[collectionName];
 };
 
-Processor.prototype.ensureCollection = function ensureCollection(
+ServerConnection.prototype.ensureCollection = function ensureCollection(
   databaseName,
   collectionName,
   collection) {
-  var database = Processor._mocks[databaseName];
+  var database = this._mocks[databaseName];
   if (!database[collectionName]) {
     database[collectionName] = collection;
   } else if (database[collectionName] !== collection) {
@@ -107,11 +101,7 @@ Processor.prototype.ensureCollection = function ensureCollection(
   }
 };
 
-Processor.process = function onNewConnection(socket) {
-  Processor._connections.push(new Processor(socket, Processor._logger));
-};
-
-Processor.prototype.processSocketData = function processSocketData(buf) {
+ServerConnection.prototype.processSocketData = function processSocketData(buf) {
   var header = protocol.fromMsgHeaderBuf(buf);
   var clientReqMsg;
   var Command;
@@ -169,6 +159,25 @@ Processor.prototype.processSocketData = function processSocketData(buf) {
   if (buf.bytesRead < buf.length) {
     this.processSocketData(buf.slice(buf.bytesRead));
   }
+};
+
+function Processor(mocks) {
+  this._logger = log.getLogger('processor');
+  this._mocks = mocks;
+  this._connections = [];
+}
+
+Processor.prototype.process = function onNewConnection(socket) {
+  var serverConnection = new ServerConnection(
+    this._mocks,
+    socket,
+    this._logger);
+
+  serverConnection.on('end', function endEventHandler() {
+    serverConnection.removeListener('end', endEventHandler);
+    _.pull(this._connections, serverConnection);
+  });
+  this._connections.push(serverConnection);
 };
 
 module.exports = Processor;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/vladlosev/mongodb-fs",
   "main": "lib/mongodb-fs.js",
   "scripts": {
-    "test": "mocha test/test*.js test/commands/*_test.js",
+    "test": "mocha test/test*.js test/*_test.js test/commands/*_test.js",
     "lint": "gulp lint"
   },
   "author": {

--- a/test/multiple_instances_test.js
+++ b/test/multiple_instances_test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+var chai = require('chai');
+var mongoose = require('mongoose');
+var path = require('path');
+var MongoDbFs = require('../lib/mongodb-fs');
+
+var logConfig = {
+  level: process.env.LOG_LEVEL || 'warn',
+  category: path.basename(__filename)
+};
+
+// Chai uses properties rather than methods for assertions.
+/* eslint-disable no-unused-expressions */
+
+describe('Multi-instance support', function() {
+  var ModelOne;
+  var ModelTwo;
+  var databaseOne = {
+    collectionOne: [{_id: new mongoose.Types.ObjectId(), key: 'value'}]
+  };
+  var databaseTwo = {};
+
+  var serverOne = new MongoDbFs({
+    mocks: {fakedbone: databaseOne},
+    port: 27027,
+    log: logConfig
+  });
+  var serverTwo = new MongoDbFs({
+    mocks: {fakedbtwo: databaseTwo},
+    port: 27028,
+    log: logConfig
+  });
+
+  before(function(done) {
+    var connectionOne = mongoose.createConnection();
+    var connectionTwo = mongoose.createConnection();
+    ModelOne = connectionOne.model(
+      'ModelOne',
+      new mongoose.Schema(
+        {any: mongoose.Schema.Types.Mixed},
+        {collection: 'collectionOne', cache: false}));
+    ModelTwo = connectionTwo.model(
+      'ModelTwo',
+      new mongoose.Schema(
+        {any: mongoose.Schema.Types.Mixed},
+        {collection: 'collectionTwo', cache: false}));
+
+    var serverOptions = {server: {poolSize: 1}};
+
+    serverOne.start(function(error) {
+      if (error) return done(error);
+      serverTwo.start(function(error) {
+        if (error) return done(error);
+        connectionOne.open(
+          'mongodb://localhost:27027/fakedbone',
+          serverOptions,
+          function(error) {
+            if (error) return done(error);
+            connectionTwo.open(
+              'mongodb://localhost:27028/fakedbtwo',
+              serverOptions,
+              done);
+        });
+      });
+    });
+  });
+
+  after(function(done) {
+    mongoose.disconnect(function() {
+      serverOne.stop(function() {
+        serverTwo.stop(done);
+      });
+    });
+  });
+
+  it('supports multiple server instances', function(done) {
+    chai.expect(databaseTwo.collectionTwo).to.not.exist;
+    ModelOne.findOne({}, function(error, result) {
+      if (error) return done(error);
+      ModelTwo.collection.insert(result.toObject(), function(error) {
+        if (error) return done(error);
+        chai.expect(databaseTwo.collectionTwo).to.have.length(1);
+        chai.expect(databaseTwo.collectionTwo[0])
+          .to.have.property('key', 'value');
+        done();
+      });
+    });
+  });
+});

--- a/test/testFilterItems.js
+++ b/test/testFilterItems.js
@@ -23,10 +23,6 @@ describe('filterItems', function() {
     {_id: 2, field1: [2, 3], field2: {a: 100, b: 200}},
     {_id: 3, field1: [5, 6, 7]}];
 
-  before(function() {
-    filter.init();
-  });
-
   describe('logical connectives', function() {
     it('$and', function() {
       var filtered = filter.filterItems(items,


### PR DESCRIPTION
@parkr @rodaine This change adds support for using multiple instances of the mock server. instead of writing
```js
var mongodbFs = require('mongodb-fs');
mongodbFs.init(config);
mongodbFs.start(callback);
```
one can now write
```js
var MongodbFs = require('mongodb-fs');
var server = new MongodbFs(config);
server.start(callback);
```
The old access pattern is still supported. The change allows one to test client code that needs to access different database connections.