### PR TITLE
Fixes failure propagation from filtering operation.

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -2,6 +2,7 @@
 
 var filter = require('../filter');
 var projection = require('../projection');
+var utils = require('../utils');
 var BaseCommand = require('./base');
 
 function Find(server) {
@@ -20,15 +21,15 @@ Find.prototype.handle = function(clientReqMsg) {
   }
   try {
     if (!projection.validateProjection(clientReqMsg.returnFieldSelector)) {
-      throw new Error(
+      throw new utils.InputDataError(
         'BadValue Projection cannot have a mix of inclusion and exclusion.');
     }
     docs = filter.filterItems(collection, query);
-  } catch (err) {
-    if (err.message.match(/^BadValue /)) {
-      return {documents: [{'$err': err.message}]};
+  } catch (error) {
+    if (error instanceof utils.InputDataError) {
+      return {documents: [{'$err': error.message}]};
     } else {
-      throw err;
+      throw error;
     }
   }
   var skip = clientReqMsg.numberToSkip;

--- a/lib/commands/find_and_modify.js
+++ b/lib/commands/find_and_modify.js
@@ -17,8 +17,11 @@ BaseCommand.setUpCommand(FindAndModify, 'findandmodify');
 function getErrorReply(error) {
   if (error instanceof utils.InputDataError) {
     return getErrorReply(error.message);
+  } else if (error instanceof Error) {
+    throw error;
+  } else {
+    return {documents: [{ok: false, errmsg: error}]};
   }
-  return {documents: [{ok: false, errmsg: error}]};
 }
 
 

--- a/lib/commands/find_and_modify.js
+++ b/lib/commands/find_and_modify.js
@@ -14,20 +14,29 @@ function FindAndModify(server) {
 }
 BaseCommand.setUpCommand(FindAndModify, 'findandmodify');
 
-function getErrorReply(errorMessage) {
-  return {documents: [{ok: false, errmsg: errorMessage}]};
+function getErrorReply(error) {
+  if (error instanceof utils.InputDataError) {
+    return getErrorReply(error.message);
+  }
+  return {documents: [{ok: false, errmsg: error}]};
 }
+
 
 FindAndModify.prototype.handle = function(clientReqMsg) {
   this.logger.debug(this.commandName);
 
   var collection = this.getCollection(clientReqMsg);
-  var docs = filter.filterItems(collection, clientReqMsg.query.query);
   var updateKeys = Object.keys(clientReqMsg.query.update || {});
   var firstOperatorIndex = _.findIndex(updateKeys, utils.isOperator);
   var firstNonOperatorIndex = _.findIndex(updateKeys, function(key) {
     return !utils.isOperator(key);
   });
+  var docs;
+  try {
+    docs = filter.filterItems(collection, clientReqMsg.query.query);
+  } catch (error) {
+    return getErrorReply(error);
+  }
   if (firstOperatorIndex >= 0 && firstNonOperatorIndex >= 0) {
     var errorMessage;
     if (firstOperatorIndex < firstNonOperatorIndex) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -17,15 +17,23 @@ function Update(server) {
 }
 BaseCommand.setUpCommand(Update, 'update');
 
-function getErrorReply(message) {
-  return {documents: {ok: false, err: message}};
+function getErrorReply(error) {
+  if (error instanceof utils.InputDataError) {
+    return getErrorReply(error.message);
+  }
+  return {documents: {ok: false, err: error}};
 }
 
 Update.prototype.handle = function(clientReqMsg) {
   this.logger.debug(this.commandName);
 
   var collection = this.getCollection(clientReqMsg);
-  var docs = filter.filterItems(collection, clientReqMsg.selector);
+  var docs;
+  try {
+    docs = filter.filterItems(collection, clientReqMsg.selector);
+  } catch (error) {
+    return getErrorReply(error);
+  }
   var updateContainsOnlyOperators = _.every(clientReqMsg.update, keyIsOperator);
 
   if (clientReqMsg.flags.multiUpdate && !updateContainsOnlyOperators) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -20,6 +20,8 @@ BaseCommand.setUpCommand(Update, 'update');
 function getErrorReply(error) {
   if (error instanceof utils.InputDataError) {
     return getErrorReply(error.message);
+  } else if (error instanceof Error) {
+    throw error;
   }
   return {documents: {ok: false, err: error}};
 }

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -36,7 +36,8 @@ function evaluateTopLevelExpression(context, selector) {
         case '$nor':
           return evaluateTopLevelOperator(context, key, value);
         default:
-          throw new Error('BadValue unknown top level operator: ' + key);
+          throw new utils.InputDataError(
+            'BadValue unknown top level operator: ' + key);
       }
     } else {
       return evaluateFieldExpression(context, key, value);
@@ -54,7 +55,7 @@ function evaluateTopLevelOperator(context, operator, args) {
   logger.trace('In evaluateTopLevelOperator(', context.path, ',', operator, ',', args, ')');
 
   if (!Array.isArray(args)) {
-    throw new Error('BadValue ' + operator + ' needs an array');
+    throw new utils.InputDataError('BadValue ' + operator + ' needs an array');
   }
   var result = operator === '$and';
   _.forEach(args, function(arg) {
@@ -79,7 +80,7 @@ function evaluateFieldExpression(parentContext, selector, value) {
     var options = {};
     if ('$options' in value) {
       if (!('$regex' in value)) {
-        throw new Error('$options needs $regex');
+        throw new utils.InputDataError('$options needs $regex');
       }
       options.$options = value.$options;
     }
@@ -227,14 +228,15 @@ function evaluateOperator(context, operator, value, options) {
         return !evaluateValue(context, value);
       }
       if (!_.isPlainObject(value)) {
-        throw new Error(
+        throw new utils.InputDataError(
           'BadValue $not needs a regex or a document: ' + util.format(value));
       }
       return !_.every(value, function(element, key) {
         if (!/^[$]/.test(key)) {
-          throw new Error('BadValue unknown operator: ' + util.format(key));
+          throw new utils.InputDataError(
+            'BadValue unknown operator: ' + util.format(key));
         } else if (key === '$regex') {
-          throw new Error('BadValue $not cannot have a regex');
+          throw new utils.InputDataError('BadValue $not cannot have a regex');
         }
         return evaluateOperator(context, key, element);
       });
@@ -242,12 +244,13 @@ function evaluateOperator(context, operator, value, options) {
       comparer = function(context, value) {
         function validateArg(unused, key) {
           if (/^[$]/.test(key)) {
-            throw new Error(
+            throw new utils.InputDataError(
               'BadValue no $ expressions in $all: ' + util.format(value));
           }
         }
         if (!Array.isArray(value)) {
-          throw new Error('BadValue $all needs an array: ' + util.format(value));
+          throw new utils.InputDataError(
+            'BadValue $all needs an array: ' + util.format(value));
         }
         result = true;
         for (var i = 0; i < value.length; ++i) {
@@ -282,7 +285,7 @@ function evaluateOperator(context, operator, value, options) {
       };
       break;
     default:
-      throw new Error('BadValue unknown operator: ' + operator);
+      throw new utils.InputDataError('BadValue unknown operator: ' + operator);
   }
   result = evaluateComparerOrRecurse(context, comparer, value);
   logger.trace('Result:', result);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,12 +1,16 @@
 'use strict';
 
 var _ = require('lodash');
+var util = require('util');
 var ObjectID = require('bson').ObjectID;
 
-function InputDataError(message) {
+function InputDataError(message, code) {
   this.message = message;
+  if (code) {
+    this.code = code;
+  }
 }
-InputDataError.prototype = new Error();
+util.inherits(InputDataError, Error);
 
 
 // Allows comparing ObjectIDs loaded from different modules.

--- a/test/commands/find_and_modify_test.js
+++ b/test/commands/find_and_modify_test.js
@@ -122,6 +122,21 @@ describe('findAndModify', function() {
     });
   });
 
+  it('rejects invalid filters', function(done) {
+    Item.collection.findAndModify(
+      {'$eq': 2},
+      null,
+      {'$set': {a: 'new value'}},
+      function(error, item) {
+        expect(error).to.have.property('ok', false);
+        expect(error).to.have.property('name', 'MongoError');
+        expect(error)
+          .to.have.property('message')
+          .to.have.string('BadValue unknown top level operator: $eq');
+        done();
+    });
+  });
+
   it('rejects invalid requested projections', function(done) {
     Item.collection.findAndModify(
       {b: 1},

--- a/test/commands/find_and_modify_test.js
+++ b/test/commands/find_and_modify_test.js
@@ -127,7 +127,7 @@ describe('findAndModify', function() {
       {'$eq': 2},
       null,
       {'$set': {a: 'new value'}},
-      function(error, item) {
+      function(error) {
         expect(error).to.have.property('ok', false);
         expect(error).to.have.property('name', 'MongoError');
         expect(error)

--- a/test/commands/update_test.js
+++ b/test/commands/update_test.js
@@ -338,14 +338,26 @@ describe('update', function() {
     fakeDatabase.items = [{key: 'value1'}];
     Item.collection.update(
       {key: 'value1'},
-      {$set: {'key.k2.k3': 5 }}, function(error) {
+      {$set: {'key.k2.k3': 5}},
+      function(error) {
+        expect(error).to.exist;
+        expect(error.ok).to.be.false;
+        expect(error)
+          .to.have.property(
+            'err',
+            'cannot use the part (k2 of key.k2.k3)' +
+            " to traverse the element ({ key: 'value1' })");
+        done();
+      });
+  });
+
+  it('rejects invalid filters', function(done) {
+    fakeDatabase.items = [{key: 'value1'}];
+    Item.collection.update({'$eq': 2}, {$set: {'value': 5}}, function(error) {
       expect(error).to.exist;
       expect(error.ok).to.be.false;
       expect(error)
-        .to.have.property(
-          'err',
-          'cannot use the part (k2 of key.k2.k3)' +
-          " to traverse the element ({ key: 'value1' })");
+        .to.have.property('err', 'BadValue unknown top level operator: $eq');
       done();
     });
   });


### PR DESCRIPTION
@parkr @bigthyme This change fixes a bug in dealing with errors arising in filtering module in `findandmodify` and `update` commands. The filter parsing errors there were not caught and returned to a user; they were escaping instead. The fix is implemented by making the user-caused errors a separate type. This will also help implement `$match` in `aggregate`.