### PR TITLE
Implements match pipeline stage

### DIFF
--- a/lib/commands/aggregate.js
+++ b/lib/commands/aggregate.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var util = require('util');
 
+var filter = require('../filter');
 var utils = require('../utils');
 var BaseCommand = require('./base');
 var ElementWrapper = require('../element-wrapper');
@@ -169,6 +170,18 @@ function executeGroupStage(groupSpec, documents) {
   return _.values(groups);
 }
 
+function executeMatchStage(query, documents) {
+  try {
+    return filter.filterItems(documents, query);
+  } catch (error) {
+    if (error instanceof utils.InputDataError) {
+      return getErrorReply(error.message)
+    } else {
+      throw error;
+    }
+  }
+}
+
 Aggregate.prototype.handle = function(clientReqMsg) {
   this.logger.debug(this.commandName);
 
@@ -182,7 +195,6 @@ Aggregate.prototype.handle = function(clientReqMsg) {
   }
   for (var index = 0; index < pipeline.length; ++index) {
     var stage = pipeline[index];
-    var newDocs = [];
     if (!_.isPlainObject(stage)) {
       return getErrorReply(
         util.format('exception: pipeline element %d is not an object', index),
@@ -195,22 +207,27 @@ Aggregate.prototype.handle = function(clientReqMsg) {
         'must contain exactly one field.',
         16435);
     }
+    var stageResult;
     switch (keys[0]) {
       case '$group':
-        newDocs = executeGroupStage(stage.$group, docs);
-        if (!_.isArray(newDocs)) {
-          return newDocs;  // Is actually an error.
-        }
+        stageResult = executeGroupStage(stage.$group, docs);
+        break;
+      case '$match':
+        stageResult = executeMatchStage(stage.$match, docs);
         break;
       // TODO(vladlosev): handle more stages.
       default:
-        return getErrorReply(
+        stageResult = getErrorReply(
           util.format(
             "exception: Unrecognized pipeline stage name: '%s'",
             keys[0]),
           16436);
     }
-    docs = newDocs;
+    if (_.isArray(stageResult)) {
+      docs = stageResult;
+    } else {
+      return stageResult;  // Is actually an error.
+    }
   }
   return {documents: {ok: true, result: docs}};
 };

--- a/lib/commands/aggregate.js
+++ b/lib/commands/aggregate.js
@@ -223,10 +223,12 @@ Aggregate.prototype.handle = function(clientReqMsg) {
             keys[0]),
           16436);
     }
+    // A stage will return either its result which is always an array or a
+    // plain object with error response to return to the client.
     if (_.isArray(stageResult)) {
       docs = stageResult;
     } else {
-      return stageResult;  // Is actually an error.
+      return stageResult;
     }
   }
   return {documents: {ok: true, result: docs}};

--- a/lib/commands/aggregate.js
+++ b/lib/commands/aggregate.js
@@ -175,7 +175,7 @@ function executeMatchStage(query, documents) {
     return filter.filterItems(documents, query);
   } catch (error) {
     if (error instanceof utils.InputDataError) {
-      return getErrorReply(error.message)
+      return getErrorReply(error.message);
     } else {
       throw error;
     }

--- a/test/commands/aggregate_test.js
+++ b/test/commands/aggregate_test.js
@@ -114,6 +114,29 @@ describe('aggregate', function() {
       });
     });
 
+    it('chains stages in a pipeline', function(done) {
+      fakeDatabase.items = [
+        {_id: id1, key: 1, value: 1},
+        {_id: id2, key: 1, value: 2},
+        {_id: id3, key: 2, value: 2},
+        {_id: id3, key: 3, value: 5}
+      ];
+      Item.aggregate(
+        [
+          {'$group': {_id: '$key', total: {'$sum': '$value'}}},
+          {'$match': {total: {'$gt': 2}}}
+        ],
+        function(error, items) {
+          if (error) return done(error);
+
+          expect(items).to.deep.equal([
+            {_id: 1, total: 3},
+            {_id: 3, total: 5}
+          ]);
+          done();
+      });
+    });
+
     it('treats missing _id keys as nulls when grouping', function(done) {
       fakeDatabase.items = [
         {_id: id1, key: 'a', value: 3},

--- a/test/commands/aggregate_test.js
+++ b/test/commands/aggregate_test.js
@@ -298,7 +298,7 @@ describe('aggregate', function() {
     it('reject invalid match queries', function(done) {
       Item.aggregate(
         [{'$match': {'$eq': 3}}],
-        function(error, items) {
+        function(error) {
           expect(error).to.have.property('ok', false);
           expect(error)
             .to.have.property('message')

--- a/test/commands/aggregate_test.js
+++ b/test/commands/aggregate_test.js
@@ -59,197 +59,252 @@ describe('aggregate', function() {
     });
   });
 
-  it('supports multiple aggregations', function(done) {
-    fakeDatabase.items = [
-      {_id: id1, key: 'a', value: 1, value2: 10},
-      {_id: id2, key: 'b', value: 1, value2: 15},
-      {_id: id3, key: 'b', value: 2, value2: 25}
-    ];
-    Item.aggregate(
-      [{
-        '$group': {
-          _id: '$key',
-          total: {'$sum': '$value'}, total2: {'$sum': '$value2'}
-        }
-      }],
-      function(error, items) {
-        if (error) return done(error);
-        expect(items).to.deep.equal([
-          {_id: 'a', total: 1, total2: 10},
-          {_id: 'b', total: 3, total2: 40}
-        ]);
-        done();
+  describe('$group', function() {
+    it('supports multiple groupings', function(done) {
+      fakeDatabase.items = [
+        {_id: id1, key: 'a', value: 1, value2: 10},
+        {_id: id2, key: 'b', value: 1, value2: 15},
+        {_id: id3, key: 'b', value: 2, value2: 25}
+      ];
+      Item.aggregate(
+        [{
+          '$group': {
+            _id: '$key',
+            total: {'$sum': '$value'}, total2: {'$sum': '$value2'}
+          }
+        }],
+        function(error, items) {
+          if (error) return done(error);
+          expect(items).to.deep.equal([
+            {_id: 'a', total: 1, total2: 10},
+            {_id: 'b', total: 3, total2: 40}
+          ]);
+          done();
+      });
+    });
+
+    it('supports dates as _ids', function(done) {
+      fakeDatabase.items = [
+        {_id: id1, key: new Date('1995-08-08'), value: 1},
+        {_id: id2, key: new Date('1998-10-28'), value: 1},
+        {_id: id3, key: new Date('1998-10-28'), value: 2}
+      ];
+      Item.aggregate(
+        [{'$group': {_id: '$key', total: {'$sum': '$value'}}}],
+        function(error, items) {
+          if (error) return done(error);
+          expect(items).to.deep.equal([
+            {_id: new Date('1995-08-08'), total: 1},
+            {_id: new Date('1998-10-28'), total: 3}
+          ]);
+          done();
+      });
+    });
+
+    it('supports single stage pipeline as object', function(done) {
+      Item.aggregate(
+        {'$group': {_id: '$key', total: {'$sum': '$value'}}},
+        function(error, items) {
+          if (error) return done(error);
+          expect(items).to.deep.equal([
+            {_id: 'a', total: 1},
+            {_id: 'b', total: 3}
+          ]);
+          done();
+      });
+    });
+
+    it('treats missing _id keys as nulls when grouping', function(done) {
+      fakeDatabase.items = [
+        {_id: id1, key: 'a', value: 3},
+        {_id: id3, value: 5}
+      ];
+      Item.aggregate(
+        [{'$group': {_id: '$key', total: {'$sum': '$value'}}}],
+        function(error, items) {
+          if (error) return done(error);
+          expect(items).to.deep.equal([
+            {_id: 'a', total: 3},
+            {_id: null, total: 5}
+          ]);
+          done();
+      });
+    });
+
+    it('returns empty array given empty input', function(done) {
+      fakeDatabase.items = [];
+      Item.aggregate(
+        [{'$group': {_id: '$key', total: {'$sum': '$value'}}}],
+        function(error, items) {
+          if (error) return done(error);
+          expect(items).to.deep.equal([]);
+          done();
+      });
+    });
+
+    it('rejects non-objects as pipeline stages', function(done) {
+      Item.collection.aggregate(
+        [1],
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('code', 15942);
+          expect(error)
+            .to.have.property('message')
+            .to.match(/exception: pipeline element 0 is not an object/);
+          done();
+      });
+    });
+
+    it('rejects multiple fields in pipeline stages', function(done) {
+      Item.collection.aggregate(
+        [{
+          '$match': {a: 1, b: 1},
+          '$group': {_id: '$a', total: {'$sum': '$b'}}
+        }],
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('code', 16435);
+          expect(error)
+            .to.have.property('message')
+            .to.have.string(
+              'exception: A pipeline stage specification object ' +
+              'must contain exactly one field.');
+          done();
+      });
+    });
+
+    it('rejects unknown pipeline stage names', function(done) {
+      Item.collection.aggregate(
+        [{a: 1}],
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('code', 16436);
+          expect(error)
+            .to.have.property('message')
+            .to.have.string("exception: Unrecognized pipeline stage name: 'a'");
+          done();
+      });
+    });
+
+    it('rejects group specification without _id', function(done) {
+      Item.collection.aggregate(
+        [{'$group': {total: {'$sum': 1}}}],
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('code', 15955);
+          expect(error)
+            .to.have.property('message')
+            .to.have.string(
+              'exception: a group specification must include an _id');
+          done();
+      });
+    });
+
+    it('rejects invalid group aggregate field expressions', function(done) {
+      Item.collection.aggregate(
+        [{'$group': {_id: '$a', total: 1}}],
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('code', 15951);
+          expect(error)
+            .to.have.property('message')
+            .to.have.string(
+              "exception: the group aggregate field 'total' " +
+              'must be defined as an expression inside an object');
+          done();
+      });
+    });
+
+    it('rejects empty computed aggregate', function(done) {
+      Item.collection.aggregate(
+        [{'$group': {_id: '$a', total: {}}}],
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('code', 15954);
+          expect(error)
+            .to.have.property('message')
+            .to.have.string(
+              "exception: the computed aggregate 'total' " +
+              'must specify exactly one operator');
+          done();
+      });
+    });
+
+    it('rejects computed aggregate with multiple keys', function(done) {
+      Item.collection.aggregate(
+        [{'$group': {_id: '$a', total: {'$sum': '$a', '$max': '$a'}}}],
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('code', 15954);
+          expect(error)
+            .to.have.property('message')
+            .to.have.string(
+              "exception: the computed aggregate 'total' " +
+              'must specify exactly one operator');
+          done();
+      });
+    });
+
+    it('rejects computed aggregate with multiple keys', function(done) {
+      Item.collection.aggregate(
+        [{'$group': {_id: '$a', total: {x: '$b'}}}],
+        function(error) {
+          expect(error).to.have.property('ok', false);
+          expect(error).to.have.property('code', 15952);
+          expect(error)
+            .to.have.property('message')
+            .to.equal("exception: unknown group operator 'x'");
+          done();
+      });
     });
   });
 
-  it('supports dates as _ids', function(done) {
-    fakeDatabase.items = [
-      {_id: id1, key: new Date('1995-08-08'), value: 1},
-      {_id: id2, key: new Date('1998-10-28'), value: 1},
-      {_id: id3, key: new Date('1998-10-28'), value: 2}
-    ];
-    Item.aggregate(
-      [{'$group': {_id: '$key', total: {'$sum': '$value'}}}],
-      function(error, items) {
-        if (error) return done(error);
-        expect(items).to.deep.equal([
-          {_id: new Date('1995-08-08'), total: 1},
-          {_id: new Date('1998-10-28'), total: 3}
-        ]);
-        done();
+  describe('$match', function() {
+    it('filters documents', function(done) {
+      fakeDatabase.items = [
+        {_id: id1, key: 'a', value: 1},
+        {_id: id2, key: 'b', value: 3},
+        {_id: id3, key: 'b', value: 4}
+      ];
+      Item.aggregate(
+        [{'$match': {value: {'$gt': 2}}}],
+        function(error, items) {
+          if (error) return done(error);
+          expect(items).to.deep.equal([
+            {_id: id2, key: 'b', value: 3},
+            {_id: id3, key: 'b', value: 4}
+          ]);
+          done();
+      });
     });
-  });
 
-  it('supports single stage pipeline as object', function(done) {
-    Item.aggregate(
-      {'$group': {_id: '$key', total: {'$sum': '$value'}}},
-      function(error, items) {
-        if (error) return done(error);
-        expect(items).to.deep.equal([
-          {_id: 'a', total: 1},
-          {_id: 'b', total: 3}
-        ]);
-        done();
+    it('supports filtering on subdocuments', function(done) {
+      fakeDatabase.items = [
+        {_id: id1, key: 'a', value: 1},
+        {_id: id2, key: 'b', value: {x: 5}},
+        {_id: id3, key: 'b', value: {x: 7}}
+      ];
+      Item.aggregate(
+        [{'$match': {'value.x': 5}}],
+        function(error, items) {
+          if (error) return done(error);
+
+          expect(items)
+            .to.deep.equal([{_id: id2, key: 'b', value: {x: 5}}]);
+          done();
+      });
     });
-  });
 
-  it('treats missing _id keys as nulls when grouping', function(done) {
-    fakeDatabase.items = [
-      {_id: id1, key: 'a', value: 3},
-      {_id: id3, value: 5}
-    ];
-    Item.aggregate(
-      [{'$group': {_id: '$key', total: {'$sum': '$value'}}}],
-      function(error, items) {
-        if (error) return done(error);
-        expect(items).to.deep.equal([
-          {_id: 'a', total: 3},
-          {_id: null, total: 5}
-        ]);
-        done();
-    });
-  });
-
-  it('returns empty array given empty input', function(done) {
-    fakeDatabase.items = [];
-    Item.aggregate(
-      [{'$group': {_id: '$key', total: {'$sum': '$value'}}}],
-      function(error, items) {
-        if (error) return done(error);
-        expect(items).to.deep.equal([]);
-        done();
-    });
-  });
-
-  it('rejects non-objects as pipeline stages', function(done) {
-    Item.collection.aggregate(
-      [1],
-      function(error) {
-        expect(error).to.have.property('ok', false);
-        expect(error).to.have.property('code', 15942);
-        expect(error)
-          .to.have.property('message')
-          .to.match(/exception: pipeline element 0 is not an object/);
-        done();
-    });
-  });
-
-  it('rejects multiple fields in pipeline stages', function(done) {
-    Item.collection.aggregate(
-      [{'$match': {a: 1, b: 1}, '$group': {_id: '$a', total: {'$sum': '$b'}}}],
-      function(error) {
-        expect(error).to.have.property('ok', false);
-        expect(error).to.have.property('code', 16435);
-        expect(error)
-          .to.have.property('message')
-          .to.have.string(
-            'exception: A pipeline stage specification object ' +
-            'must contain exactly one field.');
-        done();
-    });
-  });
-
-  it('rejects unknown pipeline stage names', function(done) {
-    Item.collection.aggregate(
-      [{a: 1}],
-      function(error) {
-        expect(error).to.have.property('ok', false);
-        expect(error).to.have.property('code', 16436);
-        expect(error)
-          .to.have.property('message')
-          .to.have.string("exception: Unrecognized pipeline stage name: 'a'");
-        done();
-    });
-  });
-
-  it('rejects group specification without _id', function(done) {
-    Item.collection.aggregate(
-      [{'$group': {total: {'$sum': 1}}}],
-      function(error) {
-        expect(error).to.have.property('ok', false);
-        expect(error).to.have.property('code', 15955);
-        expect(error)
-          .to.have.property('message')
-          .to.have.string(
-            'exception: a group specification must include an _id');
-        done();
-    });
-  });
-
-  it('rejects invalid group aggregate field expressions', function(done) {
-    Item.collection.aggregate(
-      [{'$group': {_id: '$a', total: 1}}],
-      function(error) {
-        expect(error).to.have.property('ok', false);
-        expect(error).to.have.property('code', 15951);
-        expect(error)
-          .to.have.property('message')
-          .to.have.string(
-            "exception: the group aggregate field 'total' " +
-            'must be defined as an expression inside an object');
-        done();
-    });
-  });
-
-  it('rejects empty computed aggregate', function(done) {
-    Item.collection.aggregate(
-      [{'$group': {_id: '$a', total: {}}}],
-      function(error) {
-        expect(error).to.have.property('ok', false);
-        expect(error).to.have.property('code', 15954);
-        expect(error)
-          .to.have.property('message')
-          .to.have.string(
-            "exception: the computed aggregate 'total' " +
-            'must specify exactly one operator');
-        done();
-    });
-  });
-
-  it('rejects computed aggregate with multiple keys', function(done) {
-    Item.collection.aggregate(
-      [{'$group': {_id: '$a', total: {'$sum': '$a', '$max': '$a'}}}],
-      function(error) {
-        expect(error).to.have.property('ok', false);
-        expect(error).to.have.property('code', 15954);
-        expect(error)
-          .to.have.property('message')
-          .to.have.string(
-            "exception: the computed aggregate 'total' " +
-            'must specify exactly one operator');
-        done();
-    });
-  });
-
-  it('rejects computed aggregate with multiple keys', function(done) {
-    Item.collection.aggregate(
-      [{'$group': {_id: '$a', total: {x: '$b'}}}],
-      function(error) {
-        expect(error).to.have.property('ok', false);
-        expect(error).to.have.property('code', 15952);
-        expect(error)
-          .to.have.property('message', "exception: unknown group operator 'x'");
-        done();
+    it('reject invalid match queries', function(done) {
+      Item.aggregate(
+        [{'$match': {'$eq': 3}}],
+        function(error, items) {
+          expect(error).to.have.property('ok', false);
+          expect(error)
+            .to.have.property('message')
+            .to.match(/BadValue unknown top level operator: \$eq/);
+          done();
+      });
     });
   });
 


### PR DESCRIPTION
@parkr @bigthyme This implements `$match` pipeline for aggregation framework. You can now run primitive reports against mocked collections.

The change is best viewed with whitespace ignored.