### PR TITLE
Implements $size aggregation expression operator.

### DIFF
--- a/lib/aggregate/expression.js
+++ b/lib/aggregate/expression.js
@@ -8,6 +8,24 @@ var ElementWrapper = require('../element-wrapper');
 
 var wrapElementForAccess = ElementWrapper.wrapElementForAccess;
 
+function getTypeName(value) {
+  if (_.isNumber(value)) {
+    return 'NumberDouble';
+  } else if (_.isString(value)) {
+    return 'String';
+  } else if (_.isDate(value)) {
+    return 'Date';
+  } else if (_.isBoolean(value)) {
+    return 'Bool';
+  } else if (value === null) {
+    return 'EOO';
+  } else if (_.isArray(value)) {
+    return 'Array';
+  } else {
+    return 'Object';
+  }
+}
+
 // Retrieves a value for aggregating, based on the field expression
 // supplied in an aggregation stage.
 function getFieldValue(doc, expression) {
@@ -60,6 +78,16 @@ function validateExpression(expression) {
               16020);
           }
           break;
+        case '$size':
+         if (_.isArray(params) && params.length !== 1) {
+            return aggregateUtils.getErrorReply(
+              util.format(
+                'exception: Expression $size takes exactly 1 arguments. ' +
+                '%d were passed in.',
+                params.length),
+              16020);
+         }
+         break;
         default:
           // TODO(vladlosev): Add support for other aggregation expression
           // operators.
@@ -100,6 +128,20 @@ function getExpressionValue(doc, expression) {
         return firstParamValue === null ?
           getExpressionValue(doc, params[1]) :
           firstParamValue;
+      }
+      case '$size': {
+        var paramValue = getExpressionValue(
+          doc,
+          _.isArray(params) ? params[0] : params);
+        if (_.isArray(paramValue)) {
+          return paramValue.length;
+        } else {
+          throw aggregateUtils.getErrorReply(util.format(
+              'exception: The argument to $size must be an Array, ' +
+              'but was of type: %s',
+              getTypeName(paramValue)),
+            17124);
+        }
       }
     }
   } else {

--- a/lib/commands/aggregate.js
+++ b/lib/commands/aggregate.js
@@ -232,43 +232,42 @@ function executeGroupStage(groupSpec, documents) {
     return parseError;
   }
   var groups = {};
-  for (var i = 0; i < documents.length; ++i) {
-    var doc = documents[i];
-    var groupId;
-    try {
-      groupId = aggregateExpression.getValue(doc, groupSpec._id);
-    } catch (error) {
-      if (_.isPlainObject(error)) {
-        return error;  // `error` is an error reply to send back.
+  try {
+    for (var i = 0; i < documents.length; ++i) {
+      var doc = documents[i];
+      var groupId = aggregateExpression.getValue(doc, groupSpec._id);
+
+      if (_.isUndefined(groupId)) {
+        groupId = null;
       }
-      throw error;
-    }
+      var groupKey = buildValueKey(groupId);
+      var accumulator = groups[groupKey];
 
-    if (_.isUndefined(groupId)) {
-      groupId = null;
-    }
-    var groupKey = buildValueKey(groupId);
-    var accumulator = groups[groupKey];
+      if (!accumulator) {
+        accumulator = {_id: groupId};
+        groups[groupKey] = accumulator;
+      }
 
-    if (!accumulator) {
-      accumulator = {_id: groupId};
-      groups[groupKey] = accumulator;
+      /* eslint-disable no-loop-func */
+      _.forOwn(groupOperations, function(aggregate, key) {
+        var expressionValue = aggregateExpression.getValue(
+          doc,
+          aggregate.expression);
+        aggregate.operation.accumulate(accumulator, key, expressionValue);
+      });
+      /* eslint-enable no-loop-func */
     }
-
-    /* eslint-disable no-loop-func */
-    _.forOwn(groupOperations, function(aggregate, key) {
-      var expressionValue = aggregateExpression.getValue(
-        doc,
-        aggregate.expression);
-      aggregate.operation.accumulate(accumulator, key, expressionValue);
+    _.forEach(groups, function(group) {
+      _.forOwn(groupOperations, function(aggregate, key) {
+        aggregate.operation.finalize(group, key);
+      });
     });
-    /* eslint-enable no-loop-func */
+  } catch (error) {
+    if (_.isPlainObject(error)) {
+      return error;  // `error` is an error reply to send back.
+    }
+    throw error;
   }
-  _.forEach(groups, function(group) {
-    _.forOwn(groupOperations, function(aggregate, key) {
-      aggregate.operation.finalize(group, key);
-    });
-  });
   return _.values(groups);
 }
 


### PR DESCRIPTION
@parkr @bigthyme @Phraxos This implements `$size` operator, e.g.
```js
db.collection.aggregate([{
  $group: {_id: 'user.id', maxtags: {$max: {$size: '$tags'}}}}
}]);
```
Also, refactors existing failure mode tests to be shorter.
Looking at this with the 'no whitespace' option on yields slightly better results.