### PR TITLE
Fixes comparison for ObjectIds and Booleans in $max and $min.

### DIFF
--- a/lib/commands/aggregate.js
+++ b/lib/commands/aggregate.js
@@ -44,12 +44,12 @@ function typeRank(value) {
     return 3;
   } else if (_.isString(value)) {
     return 4;
+  } else if (utils.isObjectId(value)) {
+    return 8;
   } else if (_.isPlainObject(value)) {
     return 5;
   } else if (_.isArray(value)) {
     return 6;
-  } else if (utils.isObjectId(value)) {
-    return 8;
   } else if (_.isBoolean(value)) {
     return 9;
   } else if (_.isDate(value)) {

--- a/lib/commands/aggregate.js
+++ b/lib/commands/aggregate.js
@@ -28,6 +28,8 @@ function buildValueKey(value) {
     return 'string:' + value;
   } else if (_.isDate(value)) {
     return 'date:' + value.toJSON();
+  } else if (_.isBoolean(value)) {
+    return 'bool:' + value;
   } else if (_.isNull(value) || _.isUndefined(value)) {
     return 'null:';
   } else {
@@ -39,15 +41,19 @@ function buildValueKey(value) {
 // compareValues for details.
 function typeRank(value) {
   if (_.isNumber(value)) {
-    return 1;
-  } else if (_.isString(value)) {
-    return 2;
-  } else if (_.isPlainObject(value)) {
     return 3;
-  } else if (_.isArray(value)) {
+  } else if (_.isString(value)) {
     return 4;
-  } else if (_.isDate(value)) {
+  } else if (_.isPlainObject(value)) {
     return 5;
+  } else if (_.isArray(value)) {
+    return 6;
+  } else if (utils.isObjectId(value)) {
+    return 8;
+  } else if (_.isBoolean(value)) {
+    return 9;
+  } else if (_.isDate(value)) {
+    return 10;
   } else {
     throw new Error('Unexpected value compared: ' + value);
   }
@@ -64,12 +70,9 @@ function typeRank(value) {
 // than objects.  For objects, keys are are compared lexicographically in the
 // order of appearance in the object. For keys that are equal, values are
 // compared. For arrays values are elements are compared in lexicographical
-// order.  Here is the full ranking:
-//   * Numbers
-//   * Strings
-//   * Objects
-//   * Arrays
-//   * Dates
+// order.  The full type ranking (not fully supported here) is defined in
+// http://docs.mongodb.org/manual/reference/bson-types/#bson-types-comparison-order.
+//
 // null values are not participating in the comparison and null is only
 // returned as the result of $max or $min if there are no other values to
 // consider.

--- a/test/commands/aggregate_test.js
+++ b/test/commands/aggregate_test.js
@@ -582,6 +582,53 @@ describe('aggregate', function() {
         done);
     });
 
+    it('compares ObjectIds', function(done) {
+      var idCompare1 = new mongoose.Types.ObjectId('5567d9a0f9932aef26f23bf1');
+      var idCompare2 = new mongoose.Types.ObjectId('5567d9a0f9932aef26f23bf2');
+
+      assertMaxResults(
+        [
+          {_id: id2, key: 'a', value: idCompare2},
+          {_id: id1, key: 'a', value: idCompare1}
+        ],
+        [{_id: 'a', result: idCompare2}],
+        done);
+    });
+
+    it('ranks ObjectIds higher than dates', function(done) {
+      var id = new mongoose.Types.ObjectId('5567d9a0f9932aef26f23bf1');
+
+      assertMaxResults(
+        [
+          {_id: id2, key: 'a', value: [1]},
+          {_id: id1, key: 'a', value: id}
+        ],
+        [{_id: 'a', result: id}],
+        done);
+    });
+
+    it('ranks true higher than false', function(done) {
+      assertMaxResults(
+        [
+          {_id: id2, key: 'a', value: true},
+          {_id: id1, key: 'a', value: false}
+        ],
+        [{_id: 'a', result: true}],
+        done);
+    });
+
+    it('ranks Booleans higher than ObjectIds', function(done) {
+      var id = new mongoose.Types.ObjectId();
+
+      assertMaxResults(
+        [
+          {_id: id2, key: 'a', value: id},
+          {_id: id1, key: 'a', value: false}
+        ],
+        [{_id: 'a', result: false}],
+        done);
+    });
+
     it('calculates value for dates', function(done) {
       assertMaxResults(
         [
@@ -592,10 +639,10 @@ describe('aggregate', function() {
         done);
     });
 
-    it('ranks dates higher than arrays', function(done) {
+    it('ranks dates higher than Booleans', function(done) {
       assertMaxResults(
         [
-          {_id: id2, key: 'a', value: [1]},
+          {_id: id2, key: 'a', value: true},
           {_id: id1, key: 'a', value: new Date('2009-10-01')}
         ],
         [{_id: 'a', result: new Date('2009-10-01')}],


### PR DESCRIPTION
@parkr @bigthyme @Phraxos This implements comparison for `ObjectId` and Booleans, which were missed when `$min` and `$max` were first implemented.