### PR TITLE
Fixes aggregation expression validation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "no-unused-vars": 2,
     "no-debugger": 2,
     "no-comma-dangle": 2,
+    "no-use-before-define": [2, "nofunc"],
     "eqeqeq": 2,
     "no-unreachable": 2,
     "new-parens": 2,

--- a/lib/aggregate/expression.js
+++ b/lib/aggregate/expression.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var util = require('util');
 
 var aggregateUtils = require('./utils');
+var utils = require('../utils');
 var ElementWrapper = require('../element-wrapper');
 
 var wrapElementForAccess = ElementWrapper.wrapElementForAccess;
@@ -51,6 +52,7 @@ function validateExpression(expression) {
     for (var i = 0; i < keys.length; ++i) {
       var operator = keys[i];
       var params = expression[operator];
+      var result;
 
       if (!/^[$]/.test(operator)) {
         if (i === 0) {
@@ -77,6 +79,11 @@ function validateExpression(expression) {
                 _.isArray(params) ? params.length : 1),
               16020);
           }
+          result =
+            validateExpression(params[0]) || validateExpression(params[1]);
+          if (result) {
+            return result;
+          }
           break;
         case '$size':
           if (_.isArray(params) && params.length !== 1) {
@@ -87,9 +94,24 @@ function validateExpression(expression) {
                  params.length),
                16020);
           }
+          if (!_.isArray(params)) {
+            params = [params];
+          }
+          result = validateExpression(params[0]);
+          if (result) {
+            return result;
+          }
           break;
         case '$cond':
           if (_.isArray(params)) {
+            if (params.length === 1 &&
+                _.isPlainObject(params[0]) &&
+                !_.isEmpty(params[0])) {
+              result = validateExpression(params[0]);
+              if (result) {
+                return result;
+              }
+            }
             if (params.length !== 3) {
               return aggregateUtils.getErrorReply(
                 util.format(
@@ -98,6 +120,12 @@ function validateExpression(expression) {
                   operator,
                   params.length),
                 16020);
+            }
+            result = validateExpression(params[0]) ||
+                     validateExpression(params[1]) ||
+                     validateExpression(params[2]);
+            if (result) {
+              return result;
             }
           } else if (_.isPlainObject(params)) {
             if (!('if' in params)) {
@@ -129,6 +157,12 @@ function validateExpression(expression) {
                   operator,
                   otherParams[0]),
                 17083);
+            }
+            result = validateExpression(params.if) ||
+                     validateExpression(params.then) ||
+                     validateExpression(params.else);
+            if (result) {
+              return result;
             }
           } else {
             return aggregateUtils.getErrorReply(
@@ -213,6 +247,11 @@ function getExpressionValue(doc, expression) {
               getTypeName(paramValue)),
             17124);
         }
+      }
+      case '$eq': {
+        var lhsValue = getExpressionValue(doc, params[0]);
+        var rhsValue = getExpressionValue(doc, params[1]);
+        return utils.isEqual(lhsValue, rhsValue);
       }
     }
   } else {

--- a/lib/aggregate/expression.js
+++ b/lib/aggregate/expression.js
@@ -41,7 +41,8 @@ function getFieldValue(doc, expression) {
 }
 
 // Validates parameters of an operator in an aggregation expressions.  Returns
-// null if expression is valid or en error reply to send to the client.
+// null if they are valid as a whole or en error reply to send to the client.
+// Performs recursive validation on the parameters themselves.
 function validateOperatorParams(operator, params, expectedParamCount) {
   var result;
   if (!_.isArray(params)) {

--- a/lib/aggregate/expression.js
+++ b/lib/aggregate/expression.js
@@ -41,6 +41,26 @@ function getFieldValue(doc, expression) {
   }
 }
 
+//function validateOPerator(operator, params, expectedParamCount) {
+//  if (_.isArray(params)) {
+//    if (param
+//  }
+//          if (!_.isArray(params) || params.length !== 2) {
+//            return aggregateUtils.getErrorReply(
+//              util.format(
+//                'exception: Expression $ifNull takes exactly 2 arguments. ' +
+//                '%d were passed in.',
+//                _.isArray(params) ? params.length : 1),
+//              16020);
+//          }
+//          result =
+//            validateExpression(params[0]) || validateExpression(params[1]);
+//          if (result) {
+//            return result;
+//          }
+//          break;
+//}
+
 // Validates an aggregation expression.  Returns null if expression is valid or
 // an error reply object to send to the client.
 function validateExpression(expression) {
@@ -71,18 +91,31 @@ function validateExpression(expression) {
 
       switch (operator) {
         case '$ifNull':
-          if (!_.isArray(params) || params.length !== 2) {
+          if (!_.isArray(params)) {
+            if (_.isPlainObject(params)) {
+              result = validateExpression(params);
+              if (result) {
+                return result;
+              }
+            }
             return aggregateUtils.getErrorReply(
-              util.format(
-                'exception: Expression $ifNull takes exactly 2 arguments. ' +
-                '%d were passed in.',
-                _.isArray(params) ? params.length : 1),
+              'exception: Expression $ifNull takes exactly 2 arguments. ' +
+              '1 were passed in.',
               16020);
-          }
-          result =
-            validateExpression(params[0]) || validateExpression(params[1]);
-          if (result) {
-            return result;
+          } else {
+            if (params.length !== 2) {
+              return aggregateUtils.getErrorReply(
+                util.format(
+                  'exception: Expression $ifNull takes exactly 2 arguments. ' +
+                  '%d were passed in.',
+                  params.length),
+                16020);
+            }
+            result =
+              validateExpression(params[0]) || validateExpression(params[1]);
+            if (result) {
+              return result;
+            }
           }
           break;
         case '$size':

--- a/lib/aggregate/expression.js
+++ b/lib/aggregate/expression.js
@@ -4,7 +4,6 @@ var _ = require('lodash');
 var util = require('util');
 
 var aggregateUtils = require('./utils');
-var utils = require('../utils');
 var ElementWrapper = require('../element-wrapper');
 
 var wrapElementForAccess = ElementWrapper.wrapElementForAccess;
@@ -41,25 +40,37 @@ function getFieldValue(doc, expression) {
   }
 }
 
-//function validateOPerator(operator, params, expectedParamCount) {
-//  if (_.isArray(params)) {
-//    if (param
-//  }
-//          if (!_.isArray(params) || params.length !== 2) {
-//            return aggregateUtils.getErrorReply(
-//              util.format(
-//                'exception: Expression $ifNull takes exactly 2 arguments. ' +
-//                '%d were passed in.',
-//                _.isArray(params) ? params.length : 1),
-//              16020);
-//          }
-//          result =
-//            validateExpression(params[0]) || validateExpression(params[1]);
-//          if (result) {
-//            return result;
-//          }
-//          break;
-//}
+// Validates parameters of an operator in an aggregation expressions.  Returns
+// null if expression is valid or en error reply to send to the client.
+function validateOperatorParams(operator, params, expectedParamCount) {
+  var result;
+  if (!_.isArray(params)) {
+    params = [params];
+  }
+  if (params.length === 1) {
+    result = validateExpression(params[0]);
+    if (result) {
+      return result;
+    }
+  }
+  if (params.length !== expectedParamCount) {
+    return aggregateUtils.getErrorReply(
+      util.format(
+        'exception: Expression %s takes exactly %d arguments. ' +
+        '%d were passed in.',
+        operator,
+        expectedParamCount,
+        params.length),
+      16020);
+  }
+  for (var i = 0; i < params.length; ++i) {
+    result = validateExpression(params[i]);
+    if (result) {
+      return result;
+    }
+  }
+  return null;
+}
 
 // Validates an aggregation expression.  Returns null if expression is valid or
 // an error reply object to send to the client.
@@ -91,76 +102,13 @@ function validateExpression(expression) {
 
       switch (operator) {
         case '$ifNull':
-          if (!_.isArray(params)) {
-            if (_.isPlainObject(params)) {
-              result = validateExpression(params);
-              if (result) {
-                return result;
-              }
-            }
-            return aggregateUtils.getErrorReply(
-              'exception: Expression $ifNull takes exactly 2 arguments. ' +
-              '1 were passed in.',
-              16020);
-          } else {
-            if (params.length !== 2) {
-              return aggregateUtils.getErrorReply(
-                util.format(
-                  'exception: Expression $ifNull takes exactly 2 arguments. ' +
-                  '%d were passed in.',
-                  params.length),
-                16020);
-            }
-            result =
-              validateExpression(params[0]) || validateExpression(params[1]);
-            if (result) {
-              return result;
-            }
-          }
+          result = validateOperatorParams(operator, params, 2);
           break;
         case '$size':
-          if (_.isArray(params) && params.length !== 1) {
-             return aggregateUtils.getErrorReply(
-               util.format(
-                 'exception: Expression $size takes exactly 1 arguments. ' +
-                 '%d were passed in.',
-                 params.length),
-               16020);
-          }
-          if (!_.isArray(params)) {
-            params = [params];
-          }
-          result = validateExpression(params[0]);
-          if (result) {
-            return result;
-          }
+          result = validateOperatorParams(operator, params, 1);
           break;
         case '$cond':
-          if (_.isArray(params)) {
-            if (params.length === 1 &&
-                _.isPlainObject(params[0]) &&
-                !_.isEmpty(params[0])) {
-              result = validateExpression(params[0]);
-              if (result) {
-                return result;
-              }
-            }
-            if (params.length !== 3) {
-              return aggregateUtils.getErrorReply(
-                util.format(
-                  'exception: Expression %s takes exactly 3 arguments. ' +
-                  '%d were passed in.',
-                  operator,
-                  params.length),
-                16020);
-            }
-            result = validateExpression(params[0]) ||
-                     validateExpression(params[1]) ||
-                     validateExpression(params[2]);
-            if (result) {
-              return result;
-            }
-          } else if (_.isPlainObject(params)) {
+          if (_.isPlainObject(params)) {
             if (!('if' in params)) {
               return aggregateUtils.getErrorReply(
                 util.format(
@@ -194,16 +142,8 @@ function validateExpression(expression) {
             result = validateExpression(params.if) ||
                      validateExpression(params.then) ||
                      validateExpression(params.else);
-            if (result) {
-              return result;
-            }
           } else {
-            return aggregateUtils.getErrorReply(
-              util.format(
-                'exception: Expression %s takes exactly 3 arguments. ' +
-                '1 were passed in.',
-                operator),
-              16020);
+            result = validateOperatorParams(operator, params, 3);
           }
           break;
         default:
@@ -221,6 +161,9 @@ function validateExpression(expression) {
                 operator),
               15983);
           }
+      }
+      if (result) {
+        return result;
       }
     }
   }
@@ -281,11 +224,12 @@ function getExpressionValue(doc, expression) {
             17124);
         }
       }
-      case '$eq': {
-        var lhsValue = getExpressionValue(doc, params[0]);
-        var rhsValue = getExpressionValue(doc, params[1]);
-        return utils.isEqual(lhsValue, rhsValue);
-      }
+      default:
+        // We are not supposed to get here.  Unknown operators are supposed to
+        // be caught in validateExpression.
+        throw new Error(util.format(
+          'Unknown operator %s in getExpressionValue',
+          operator));
     }
   } else {
     return getFieldValue(doc, expression);

--- a/lib/aggregate/utils.js
+++ b/lib/aggregate/utils.js
@@ -20,6 +20,8 @@ function typeRank(value) {
   } else if (_.isString(value)) {
     return 4;
   } else if (utils.isObjectId(value)) {
+    // Make the ObjectID check before the object check, to make sure we catch
+    // stray cloned ObjectIds.
     return 8;
   } else if (_.isPlainObject(value)) {
     return 5;

--- a/lib/aggregate/utils.js
+++ b/lib/aggregate/utils.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var _ = require('lodash');
+
+var utils = require('../utils');
+
 function getErrorReply(errorMessage, code) {
   var error = {ok: false, errmsg: errorMessage};
   if (code) {
@@ -8,6 +12,91 @@ function getErrorReply(errorMessage, code) {
   return {documents: [error]};
 }
 
+// Ranks a value's type for $min and $max operation. See comment for
+// compareValues for details.
+function typeRank(value) {
+  if (_.isNumber(value)) {
+    return 3;
+  } else if (_.isString(value)) {
+    return 4;
+  } else if (utils.isObjectId(value)) {
+    return 8;
+  } else if (_.isPlainObject(value)) {
+    return 5;
+  } else if (_.isArray(value)) {
+    return 6;
+  } else if (_.isBoolean(value)) {
+    return 9;
+  } else if (_.isDate(value)) {
+    return 10;
+  } else {
+    throw new Error('Unexpected value compared: ' + value);
+  }
+}
+
+// Compares values for computing result of $min and $max operations of the
+// $group stage.  Returns a negative number if a ranks lower than b, zero if
+// they rank equal, and a positive if b ranks lower than a.  NOTE: this
+// function is intended to compare only JSON objects.  Do not pass in objects
+// with circular references!
+//
+// $min and $max define full order on JavaScript constructs.  The values are
+// ranked by type.  Numbers always rank lower than strings, and strings, lower
+// than objects.  For objects, keys are are compared lexicographically in the
+// order of appearance in the object. For keys that are equal, values are
+// compared. For arrays values are elements are compared in lexicographical
+// order.  The full type ranking (not fully supported here) is defined in
+// http://docs.mongodb.org/manual/reference/bson-types/#bson-types-comparison-order.
+//
+// null values are not participating in the comparison and null is only
+// returned as the result of $max or $min if there are no other values to
+// consider.
+function compareValues(a, b) {
+  var rankDiff = typeRank(a) - typeRank(b);
+  if (rankDiff !== 0) {
+    return rankDiff;
+  }
+  var i;
+
+  if (_.isPlainObject(a)) {
+    var keysForA = _.keys(a);
+    var keysForB = _.keys(b);
+    var minKeyLength = Math.min(keysForA.length, keysForB.length);
+
+    for (i = 0; i < minKeyLength; ++i) {
+      if (keysForA[i] < keysForB[i]) {
+       return -1;
+      } else if (keysForA[i] > keysForB[i]) {
+        return 1;
+      } else {
+        var valueDiff = compareValues(a[keysForA[i]], b[keysForB[i]]);
+        if (valueDiff !== 0) {
+          return valueDiff;
+        }
+      }
+    }
+    // At this point, one of the objects in the prefix of another (both keys
+    // and values) and we only need to compare lengths.
+    return keysForA.length - keysForB.length;
+  } else if (_.isArray(a)) {
+    var minLength = Math.min(a, b);
+    for (i = 0; i < minLength; ++i) {
+      var diff = compareValues(a[i], b[i]);
+      if (diff !== 0) {
+        return diff;
+      }
+    }
+    return a.length - b.length;
+  } else if (a < b) {
+    return -1;
+  } else if (a > b) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
 module.exports = {
+  compareValues: compareValues,
   getErrorReply: getErrorReply
 };

--- a/lib/commands/aggregate.js
+++ b/lib/commands/aggregate.js
@@ -37,90 +37,6 @@ function buildValueKey(value) {
   }
 }
 
-// Ranks a value's type for $min and $max operation. See comment for
-// compareValues for details.
-function typeRank(value) {
-  if (_.isNumber(value)) {
-    return 3;
-  } else if (_.isString(value)) {
-    return 4;
-  } else if (utils.isObjectId(value)) {
-    return 8;
-  } else if (_.isPlainObject(value)) {
-    return 5;
-  } else if (_.isArray(value)) {
-    return 6;
-  } else if (_.isBoolean(value)) {
-    return 9;
-  } else if (_.isDate(value)) {
-    return 10;
-  } else {
-    throw new Error('Unexpected value compared: ' + value);
-  }
-}
-
-// Compares values for computing result of $min and $max operations of the
-// $group stage.  Returns a negative number if a ranks lower than b, zero if
-// they rank equal, and a positive if b ranks lower than a.  NOTE: this
-// function is intended to compare only JSON objects.  Do not pass in objects
-// with circular references!
-//
-// $min and $max define full order on JavaScript constructs.  The values are
-// ranked by type.  Numbers always rank lower than strings, and strings, lower
-// than objects.  For objects, keys are are compared lexicographically in the
-// order of appearance in the object. For keys that are equal, values are
-// compared. For arrays values are elements are compared in lexicographical
-// order.  The full type ranking (not fully supported here) is defined in
-// http://docs.mongodb.org/manual/reference/bson-types/#bson-types-comparison-order.
-//
-// null values are not participating in the comparison and null is only
-// returned as the result of $max or $min if there are no other values to
-// consider.
-function compareValues(a, b) {
-  var rankDiff = typeRank(a) - typeRank(b);
-  if (rankDiff !== 0) {
-    return rankDiff;
-  }
-  var i;
-
-  if (_.isPlainObject(a)) {
-    var keysForA = _.keys(a);
-    var keysForB = _.keys(b);
-    var minKeyLength = Math.min(keysForA.length, keysForB.length);
-
-    for (i = 0; i < minKeyLength; ++i) {
-      if (keysForA[i] < keysForB[i]) {
-       return -1;
-      } else if (keysForA[i] > keysForB[i]) {
-        return 1;
-      } else {
-        var valueDiff = compareValues(a[keysForA[i]], b[keysForB[i]]);
-        if (valueDiff !== 0) {
-          return valueDiff;
-        }
-      }
-    }
-    // At this point, one of the objects in the prefix of another (both keys
-    // and values) and we only need to compare lengths.
-    return keysForA.length - keysForB.length;
-  } else if (_.isArray(a)) {
-    var minLength = Math.min(a, b);
-    for (i = 0; i < minLength; ++i) {
-      var diff = compareValues(a[i], b[i]);
-      if (diff !== 0) {
-        return diff;
-      }
-    }
-    return a.length - b.length;
-  } else if (a < b) {
-    return -1;
-  } else if (a > b) {
-    return 1;
-  } else {
-    return 0;
-  }
-}
-
 function minMaxOperation(minmax) {
   return {
     accumulate: function(accumulator, key, value) {
@@ -128,7 +44,9 @@ function minMaxOperation(minmax) {
         return;
       }
       if (!(key in accumulator) ||
-          minmax(compareValues(accumulator[key], value), 0) === 0) {
+          minmax(aggregateUtils.compareValues(
+            accumulator[key],
+            value), 0) === 0) {
         accumulator[key] = value;
       }
     },

--- a/test/commands/aggregate_test.js
+++ b/test/commands/aggregate_test.js
@@ -717,6 +717,15 @@ describe('aggregate', function() {
         done);
     });
 
+    it('rejects parameter if non-operator object', function(done) {
+      assertAggregationError(
+        [],
+        [{'$group': {_id: '$a', total: {'$sum': {'$ifNull': {a: 1}}}}}],
+        16420,
+        'exception: field inclusion is not allowed inside of $expressions',
+        done);
+    });
+
     it('rejects non-array parameters', function(done) {
       assertAggregationError(
         [],

--- a/test/commands/aggregate_test.js
+++ b/test/commands/aggregate_test.js
@@ -717,15 +717,6 @@ describe('aggregate', function() {
         done);
     });
 
-    it('rejects parameter if non-operator object', function(done) {
-      assertAggregationError(
-        [],
-        [{'$group': {_id: '$a', total: {'$sum': {'$ifNull': {a: 1}}}}}],
-        16420,
-        'exception: field inclusion is not allowed inside of $expressions',
-        done);
-    });
-
     it('rejects non-array parameters', function(done) {
       assertAggregationError(
         [],
@@ -746,10 +737,19 @@ describe('aggregate', function() {
         done);
     });
 
+    it('validates parameter recursively if non-array', function(done) {
+      assertAggregationError(
+        [],
+        [{'$group': {_id: '$a', total: {'$sum': {'$ifNull': {a: 1}}}}}],
+        16420,
+        'exception: field inclusion is not allowed inside of $expressions',
+        done);
+    });
+
     it('validates first parameter recursively', function(done) {
       assertAggregationError(
         [],
-        [{'$group': {_id: '$a', total: {'$sum': {'$ifNull': [{a: 1}, 12]}}}}],
+        [{'$group': {_id: '$a', total: {'$sum': {'$ifNull': [{a: 1}]}}}}],
         16420,
         'exception: field inclusion is not allowed inside of $expressions',
         done);


### PR DESCRIPTION
@parkr @bigthyme @Phraxos This change factors out common validation code into a method, so that it will be easier to add operators in the future. Also moves comparison code into a separate location so its easier to reuse in comparison operators (soon).

The change has actually started as addition of comparison operators, then I realized this refactoring would give the code a much better structure but when I done with refactoring, the changes was becoming too big so the new operators had to go. :-/