### PR TITLE
Implements aggregation comparison operators.

### DIFF
--- a/lib/aggregate/expression.js
+++ b/lib/aggregate/expression.js
@@ -40,6 +40,33 @@ function getFieldValue(doc, expression) {
   }
 }
 
+function getComparisonOperationResult(operator, lhsValue, rhsValue) {
+  var comparisonResult = aggregateUtils.compareValues(lhsValue, rhsValue);
+
+  switch (operator) {
+    case '$eq':
+      return comparisonResult === 0;
+    case '$ne':
+      return comparisonResult !== 0;
+    case '$lt':
+      return comparisonResult < 0;
+    case '$lte':
+      return comparisonResult <= 0;
+    case '$gt':
+      return comparisonResult > 0;
+    case '$gte':
+      return comparisonResult >= 0;
+    case '$cmp':
+      return comparisonResult;
+    default:
+      // We are not supposed to get here.  Unknown operators are supposed to
+      // be caught in validateExpression.
+      throw new Error(util.format(
+        'Unknown operator %s in getExpressionValue',
+        operator));
+  }
+}
+
 // Validates parameters of an operator in an aggregation expressions.  Returns
 // null if they are valid as a whole or en error reply to send to the client.
 // Performs recursive validation on the parameters themselves.
@@ -103,6 +130,13 @@ function validateExpression(expression) {
 
       switch (operator) {
         case '$ifNull':
+        case '$eq':
+        case '$ne':
+        case '$lt':
+        case '$lte':
+        case '$gt':
+        case '$gte':
+        case '$cmp':
           result = validateOperatorParams(operator, params, 2);
           break;
         case '$size':
@@ -225,6 +259,17 @@ function getExpressionValue(doc, expression) {
             17124);
         }
       }
+      case '$eq':
+      case '$ne':
+      case '$lt':
+      case '$lte':
+      case '$gt':
+      case '$gte':
+      case '$cmp':
+        return getComparisonOperationResult(
+          operator,
+          getExpressionValue(doc, params[0]),
+          getExpressionValue(doc, params[1]));
       default:
         // We are not supposed to get here.  Unknown operators are supposed to
         // be caught in validateExpression.

--- a/lib/aggregate/utils.js
+++ b/lib/aggregate/utils.js
@@ -22,6 +22,8 @@ function typeRank(value) {
   } else if (_.isString(value)) {
     return 4;
   } else if (utils.isObjectId(value)) {
+    // Make the ObjectID check before the object check, to make sure we catch
+    // stray cloned ObjectIds.
     return 8;
   } else if (_.isPlainObject(value)) {
     return 5;

--- a/lib/aggregate/utils.js
+++ b/lib/aggregate/utils.js
@@ -15,13 +15,13 @@ function getErrorReply(errorMessage, code) {
 // Ranks a value's type for $min and $max operation. See comment for
 // compareValues for details.
 function typeRank(value) {
-  if (_.isNumber(value)) {
+  if (value === null) {
+    return 2;
+  } else if (_.isNumber(value)) {
     return 3;
   } else if (_.isString(value)) {
     return 4;
   } else if (utils.isObjectId(value)) {
-    // Make the ObjectID check before the object check, to make sure we catch
-    // stray cloned ObjectIds.
     return 8;
   } else if (_.isPlainObject(value)) {
     return 5;
@@ -81,7 +81,7 @@ function compareValues(a, b) {
     // and values) and we only need to compare lengths.
     return keysForA.length - keysForB.length;
   } else if (_.isArray(a)) {
-    var minLength = Math.min(a, b);
+    var minLength = Math.min(a.length, b.length);
     for (i = 0; i < minLength; ++i) {
       var diff = compareValues(a[i], b[i]);
       if (diff !== 0) {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "log4js": "~0.6.22"
   },
   "devDependencies": {
+    "bluebird": "^2.9.27",
     "chai": "~2.1.1",
     "chai-properties": "~1.2.0",
     "gulp": "^3.8.11",


### PR DESCRIPTION
@parkr @bigthyme @Phraxos This implements the comparison operators one can use with `$cond`: `$eq`, `$ne`, `$lt`, `$lte`, `$gt`, `$gte`, and `$cmp`. Thanks to the preceding refactorings the change itself is small, but there is quite a number of tests. The expanded tests helped catch a bug hiding in the array comparison code.