### PR TITLE
Adds support for pulling by query in update.

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -18,6 +18,17 @@ function createContext(parentContext, selectors) {
   };
 }
 
+function isTopLevelOperator(operator) {
+  switch (operator) {
+    case '$and':  // fallthrough
+    case '$or':   // fallthrough
+    case '$nor':
+      return true;
+    default:
+      return false;
+  }
+}
+
 // Many functions here need to parse query document tree and need to call each
 // other recursively, which no-use-before-define does not like.
 /* eslint-disable no-use-before-define */
@@ -30,14 +41,11 @@ function evaluateTopLevelExpression(context, selector) {
 
   var result = _.every(selector, function(value, key) {
     if (key.length > 0 && key[0] === '$') {
-      switch (key) {
-        case '$and':  // fallthrough
-        case '$or':   // fallthrough
-        case '$nor':
+      if (isTopLevelOperator(key)) {
           return evaluateTopLevelOperator(context, key, value);
-        default:
-          throw new utils.InputDataError(
-            'BadValue unknown top level operator: ' + key);
+      } else {
+        throw new utils.InputDataError(
+          'BadValue unknown top level operator: ' + key);
       }
     } else {
       return evaluateFieldExpression(context, key, value);
@@ -71,11 +79,7 @@ function evaluateTopLevelOperator(context, operator, args) {
   return operator === '$nor' ? !result : result;
 }
 
-// Evaluates a field expression such as {a: 1, b: {$gt: 2}}.
-function evaluateFieldExpression(parentContext, selector, value) {
-  logger.trace('In evaluateFieldExpression(', parentContext.path.join('.'), ',', selector, ',', value, ')');
-
-  var context = createContext(parentContext, selector.split('.'));
+function evaluateFieldExpressionInSameContext(context, value) {
   if (_.isPlainObject(value)) {
     var options = {};
     if ('$options' in value) {
@@ -101,6 +105,14 @@ function evaluateFieldExpression(parentContext, selector, value) {
   } else {
     return evaluateValue(context, value);
   }
+}
+
+// Evaluates a field expression such as {a: 1, b: {$gt: 2}}.
+function evaluateFieldExpression(parentContext, selector, value) {
+  logger.trace('In evaluateFieldExpression(', parentContext.path.join('.'), ',', selector, ',', value, ')');
+
+  var context = createContext(parentContext, selector.split('.'));
+  return evaluateFieldExpressionInSameContext(context, value);
 }
 
 // Evaluates a value in a given context.  The value may be either a literal
@@ -422,5 +434,20 @@ module.exports = {
       logger.trace('Evaluating document', doc);
       return evaluateTopLevelExpression(documentContext, selector);
     });
-  }
+  },
+  filterItemsByQuery: function(documents, selector) {
+    if (!logger) {
+      logger = log.getLogger('filter');
+    }
+    return _.filter(documents, function(doc) {
+      var documentContext = {
+        path: [],
+        exists: true,
+        value: doc
+      };
+      logger.trace('Evaluating value', doc);
+      return evaluateFieldExpressionInSameContext(documentContext, selector);
+    });
+  },
+  isTopLevelOperator: isTopLevelOperator
 };

--- a/lib/update.js
+++ b/lib/update.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var ObjectID = require('bson').ObjectID;
 
+var filter = require('./filter');
 var utils = require('./utils');
 var ElementWrapper = require('./element-wrapper');
 
@@ -103,17 +104,27 @@ function update(docs, query, updateDoc, multiUpdate, upsertedDoc) {
             } else if (updateKey === '$unset') {
               property.deleteValue();
             } else if (updateKey === '$pull') {
-              // TODO(vladlosev): Support queries in $pull,
-              // e.g. db.collection.update(
-              //        {name: 'joe'},
-              //        {$pull: {scores: {$lt : 50}}})
               arr = property.getValue();
               if (_.isUndefined(arr)) continue;
               if (!_.isArray(arr)) {
                 throw new utils.InputDataError(
                   'Cannot apply $pull to a non-array value');
               }
-              arrayPull(arr, value);
+              var keys = _.keys(value);
+              if (_.isPlainObject(value)) {
+                var matchingElements;
+                if (utils.isOperator(keys[0]) &&
+                    !filter.isTopLevelOperator(keys[0])) {
+                  matchingElements = filter.filterItemsByQuery(arr, value);
+                } else {
+                  matchingElements = filter.filterItems(arr, value);
+                }
+                for (var i = 0; i < matchingElements.length; ++i) {
+                  arrayPull(arr, matchingElements[i]);
+                }
+              } else {
+                arrayPull(arr, value);
+              }
             } else {
               property.setValue(value);
             }

--- a/test/testFilterItems.js
+++ b/test/testFilterItems.js
@@ -1443,4 +1443,12 @@ describe('filterItems', function() {
       }
     });
   });
+
+  it('combines multiple operators in `and` connection', function() {
+    var items = [{_id: 1, a: 5}, {_id: 2, a: 15}, {_id: 3, a: 25}];
+    var filtered = filter.filterItems(
+      items,
+      {a: {'$gt': 10, '$lt': 20}});
+    expect(_.pluck(filtered, '_id')).to.deep.equal([2]);
+  });
 });


### PR DESCRIPTION
@parkr @bigthyme This implements the ability to `$pull` [by query](http://docs.mongodb.org/manual/reference/operator/update/pull/#remove-all-items-that-match-a-specified-pull-condition) in the `update` operation. Something to kill time while waiting for my connection at CDG.