### PR TITLE
Fixes compatibility with Mongoose 5.x and MongoDB driver 3.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+node_js: "5.7"
 notifications:
   email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "5.7"
+node_js: "6.9"
 notifications:
   email: false
 sudo: false

--- a/lib/commands/base.js
+++ b/lib/commands/base.js
@@ -14,19 +14,20 @@ BaseCommand.setUpCommand = function(CommandType, commandName) {
 };
 
 BaseCommand.prototype.getDbAndCollectionName = function(clientReqMsg) {
-   var fullCollectionName = clientReqMsg.fullCollectionName;
-   var firstDot = fullCollectionName.indexOf('.');
-   if (firstDot === -1) {
-     throw new Error('BadValue Full collection name must contain comma');
-   }
-   var databaseName = fullCollectionName.substring(0, firstDot);
-   var collectionName = fullCollectionName.substring(firstDot + 1);
-   if (collectionName === '$cmd') {
-     fullCollectionName = clientReqMsg.query[this.commandName];
-     firstDot = fullCollectionName.indexOf('.');
-       collectionName = fullCollectionName;
-   }
-   return {database: databaseName, collection: collectionName};
+  var fullCollectionName = clientReqMsg.fullCollectionName;
+  var firstDot = fullCollectionName.indexOf('.');
+  if (firstDot === -1) {
+    throw new Error('BadValue Full collection name must contain comma');
+  }
+  var databaseName = fullCollectionName.substring(0, firstDot);
+  var collectionName = fullCollectionName.substring(firstDot + 1);
+  if (collectionName === '$cmd') {
+    fullCollectionName = clientReqMsg.query[this.commandName] ||
+      clientReqMsg.query[this.commandName.toLowerCase()];
+    firstDot = fullCollectionName.indexOf('.');
+    collectionName = fullCollectionName;
+  }
+  return {database: databaseName, collection: collectionName};
 };
 
 BaseCommand.prototype.getCollection = function(clientReqMsg) {

--- a/lib/commands/find_and_modify.js
+++ b/lib/commands/find_and_modify.js
@@ -12,7 +12,7 @@ var BaseCommand = require('./base');
 function FindAndModify(server) {
   BaseCommand.call(this, server);
 }
-BaseCommand.setUpCommand(FindAndModify, 'findandmodify');
+BaseCommand.setUpCommand(FindAndModify, 'findAndModify');
 
 function getErrorReply(error) {
   if (error instanceof utils.InputDataError) {

--- a/lib/commands/query_command.js
+++ b/lib/commands/query_command.js
@@ -13,7 +13,7 @@ QueryCommand.prototype.handle = function(clientReqMsg) {
   this.logger.debug(this.commandName);
 
   if (clientReqMsg.query.isMaster || clientReqMsg.query.ismaster) {
-    return {documents: {ismaster: true, maxWireVersion: 2, ok: true}};
+    return {documents: {ismaster: true, maxWireVersion: 2, minWireVersion: 2, ok: true}};
   } else if (clientReqMsg.query.getlasterror) {
     return this.server.lastReply;
   } else if (clientReqMsg.query.whatsmyuri) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -23,7 +23,7 @@ function getErrorReply(error) {
   } else if (error instanceof Error) {
     throw error;
   }
-  return {documents: {ok: false, err: error}};
+  return {documents: {ok: 0, err: error}};
 }
 
 Update.prototype.handle = function(clientReqMsg) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -110,7 +110,7 @@ ServerConnection.prototype.processProtocolMessage = function processProtocolMess
       clientReqMsg = protocol.fromOpQueryBuf(header, buf);
       if (clientReqMsg.fullCollectionName.match(/\.\$cmd$/)) {
         if (clientReqMsg.query) {
-          if (clientReqMsg.query.findandmodify) {
+          if (clientReqMsg.query.findandmodify || clientReqMsg.query.findAndModify) {
             Command = FindAndModify;
             break;
           } else if (clientReqMsg.query.distinct) {

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -164,7 +164,7 @@ var that = {
     }
     reply.documents = documents;
     reply.numberReturned = reply.documents.length;
-    var buf = new Buffer.alloc(36);
+    var buf = Buffer.alloc(36);
     var i = 4;
 
     buf.writeUInt32LE(reply.header.requestID, i);

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -164,7 +164,7 @@ var that = {
     }
     reply.documents = documents;
     reply.numberReturned = reply.documents.length;
-    var buf = Buffer.alloc(36);
+    var buf = new Buffer(36);
     var i = 4;
 
     buf.writeUInt32LE(reply.header.requestID, i);

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -164,7 +164,7 @@ var that = {
     }
     reply.documents = documents;
     reply.numberReturned = reply.documents.length;
-    var buf = new Buffer(36);
+    var buf = new Buffer.alloc(36);
     var i = 4;
 
     buf.writeUInt32LE(reply.header.requestID, i);

--- a/lib/update.js
+++ b/lib/update.js
@@ -178,7 +178,7 @@ function update(docs, query, updateDoc, multiUpdate, upsertedDoc) {
   } catch (error) {
     if (error instanceof utils.InputDataError) {
       return {documents: {
-        ok: false,
+        ok: 0,
         err: error.message,
         n: affectedDocuments
       }};

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "gulp-eslint": "^0.15.0",
     "gulp-load-plugins": "^1.0.0-rc.1",
     "mocha": "^2.2.5",
-    "mongoose": "~4.5.10"
+    "mongoose": "~5.6.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-eslint": "^0.15.0",
     "gulp-load-plugins": "^1.0.0-rc.1",
     "mocha": "^2.2.5",
-    "mongoose": "~5.6.7"
+    "mongodb": "~3.2.7",
+    "mongoose": "~4.13.19"
   }
 }

--- a/test/commands/aggregate_test.js
+++ b/test/commands/aggregate_test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var chai = require('chai');
-var mongoose = require('mongoose');
+var mongodb = require('mongodb');
 var Promise = require('bluebird');
 
 var TestHarness = require('../test_harness');
@@ -12,9 +12,9 @@ var TestHarness = require('../test_harness');
 describe('aggregate', function() {
   var expect = chai.expect;
 
-  var id1 = new mongoose.Types.ObjectId();
-  var id2 = new mongoose.Types.ObjectId();
-  var id3 = new mongoose.Types.ObjectId();
+  var id1 = new mongodb.ObjectId();
+  var id2 = new mongodb.ObjectId();
+  var id3 = new mongodb.ObjectId();
 
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
@@ -78,7 +78,7 @@ describe('aggregate', function() {
   }
 
   before(function(done) {
-    harness.setUpWithMongoClient(function(error) {
+    harness.setUp(function(error) {
       if (error) return done(error);
       harness.items = harness.dbClient.db('fakedb').collection('items');
       done();
@@ -86,7 +86,7 @@ describe('aggregate', function() {
   });
 
   after(function(done) {
-    harness.tearDownWithMongoClient(done);
+    harness.tearDown(done);
   });
 
   it('empty sequence returns all documents', function(done) {
@@ -602,8 +602,8 @@ describe('aggregate', function() {
     });
 
     it('compares ObjectIds', function(done) {
-      var idCompare1 = new mongoose.Types.ObjectId('5567d9a0f9932aef26f23bf1');
-      var idCompare2 = new mongoose.Types.ObjectId('5567d9a0f9932aef26f23bf2');
+      var idCompare1 = new mongodb.ObjectId('5567d9a0f9932aef26f23bf1');
+      var idCompare2 = new mongodb.ObjectId('5567d9a0f9932aef26f23bf2');
 
       assertMaxResults(
         [
@@ -615,7 +615,7 @@ describe('aggregate', function() {
     });
 
     it('ranks ObjectIds higher than arrays', function(done) {
-      var id = new mongoose.Types.ObjectId('5567d9a0f9932aef26f23bf1');
+      var id = new mongodb.ObjectId('5567d9a0f9932aef26f23bf1');
 
       assertMaxResults(
         [
@@ -637,7 +637,7 @@ describe('aggregate', function() {
     });
 
     it('ranks Booleans higher than ObjectIds', function(done) {
-      var id = new mongoose.Types.ObjectId();
+      var id = new mongodb.ObjectId();
 
       assertMaxResults(
         [
@@ -1347,13 +1347,13 @@ describe('aggregate', function() {
     });
 
     it('compares ObjectIds', function() {
-      var idCompare1 = new mongoose.Types.ObjectId('5567d9a0f9932aef26f23bf1');
-      var idCompare2 = new mongoose.Types.ObjectId('5567d9a0f9932aef26f23bf2');
+      var idCompare1 = new mongodb.ObjectId('5567d9a0f9932aef26f23bf1');
+      var idCompare2 = new mongodb.ObjectId('5567d9a0f9932aef26f23bf2');
       return assertStrictComparisonResult('$lt', idCompare1, idCompare2, true);
     });
 
     it('ranks ObjectIds higher than arrays', function() {
-      var id = new mongoose.Types.ObjectId('5567d9a0f9932aef26f23bf1');
+      var id = new mongodb.ObjectId('5567d9a0f9932aef26f23bf1');
       return assertStrictComparisonResult('$lt', ['x'], id, true);
     });
 
@@ -1362,7 +1362,7 @@ describe('aggregate', function() {
     });
 
     it('ranks Booleans higher than ObjectIds', function() {
-      var id = new mongoose.Types.ObjectId();
+      var id = new mongodb.ObjectId();
       return assertStrictComparisonResult('$lt', id, false, true);
     });
 

--- a/test/commands/count_test.js
+++ b/test/commands/count_test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var chai = require('chai');
-var mongoose = require('mongoose');
 
 var TestHarness = require('../test_harness');
 
@@ -10,12 +9,12 @@ describe('count', function() {
 
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
-  var Item;
 
   before(function(done) {
     harness.setUp(function(error) {
-      Item = mongoose.connection.models.Item;
-      done(error);
+      if (error) return done(error);
+      harness.items = harness.dbClient.db('fakedb').collection('items');
+      done();
     });
   });
 
@@ -25,7 +24,7 @@ describe('count', function() {
 
   it('returns the number of queried documents', function(done) {
     fakeDatabase.items = [{key: 1}, {key: 2}, {key: 3}];
-    Item.count({key: {$gt: 1}}, function(error, n) {
+    harness.items.count({key: {$gt: 1}}, function(error, n) {
       if (error) return done(error);
       expect(n).to.equal(2);
       done();
@@ -34,7 +33,7 @@ describe('count', function() {
 
   it('reports count of non-existent collection as zero', function(done) {
     delete fakeDatabase.items;
-    Item.count({}, function(error, n) {
+    harness.items.count({}, function(error, n) {
       if (error) return done(error);
       expect(n).to.equal(0);
       done();
@@ -43,7 +42,7 @@ describe('count', function() {
 
   it('does not create a collection if non-existent', function(done) {
     delete fakeDatabase.items;
-    Item.count({}, function(error) {
+    harness.items.count({}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase).to.not.have.property('items');
       done();

--- a/test/commands/create_indexes_test.js
+++ b/test/commands/create_indexes_test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var chai = require('chai');
-var mongoose = require('mongoose');
 
 chai.use(require('chai-properties'));
 
@@ -10,12 +9,13 @@ var TestHarness = require('../test_harness');
 describe('createIndex', function() {
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
-  var Item;
 
   before(function(done) {
     harness.setUp(function(error) {
-      Item = mongoose.connection.models.Item;
-      done(error);
+      if (error) return done(error);
+      harness.db = harness.dbClient.db('fakedb');
+      harness.items = harness.db.collection('items');
+      done();
     });
   });
 
@@ -34,7 +34,7 @@ describe('createIndex', function() {
   });
 
   it('creates an index', function(done) {
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1},
       function(error, result) {
         if (error) return done(error);
@@ -55,7 +55,8 @@ describe('createIndex', function() {
   // We need this to verify the full output of the createIndexes command.
   // Mongoose only returns the index name.
   it('creates an index using raw command', function(done) {
-    mongoose.connection.db.command(
+    var util = require('util');
+    harness.dbClient.db('fakedb').command(
       {createIndexes: 'items', indexes: [{key: {a: 1}}]},
       function(error, results) {
         if (error) return done(error);
@@ -79,7 +80,7 @@ describe('createIndex', function() {
   });
 
   it('creates multiple indices using raw command', function(done) {
-    mongoose.connection.db.command(
+    harness.dbClient.db('fakedb').command(
       {createIndexes: 'items', indexes: [{key: {a: 1}}, {key: {b: 1}}]},
       function(error, results) {
         if (error) return done(error);
@@ -106,7 +107,7 @@ describe('createIndex', function() {
       name: 'a_1',
       ns: 'fakedb.items'
     });
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {b: 1},
       function(error, result) {
         if (error) return done(error);
@@ -127,7 +128,7 @@ describe('createIndex', function() {
       name: 'a_1',
       ns: 'fakedb.items'
     });
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1},
       function(error, result) {
         if (error) return done(error);
@@ -142,7 +143,7 @@ describe('createIndex', function() {
     delete fakeDatabase.items;
     fakeDatabase['system.indexes'] = [];
 
-    mongoose.connection.db.command(
+    harness.dbClient.db('fakedb').command(
       {createIndexes: 'items', indexes: [{key: {a: 1}}]},
       function(error, results) {
         if (error) return done(error);
@@ -170,7 +171,7 @@ describe('createIndex', function() {
   });
 
   it('creates a compound index', function(done) {
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1, b: -1},
       function(error, result) {
         if (error) return done(error);
@@ -189,7 +190,7 @@ describe('createIndex', function() {
   });
 
   it('creates index on embedded field', function(done) {
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1, 'b.c': -1},
       function(error, result) {
         if (error) return done(error);
@@ -206,7 +207,7 @@ describe('createIndex', function() {
   });
 
   it('creates a background index', function(done) {
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1},
       {background: true},
       function(error, result) {
@@ -224,7 +225,7 @@ describe('createIndex', function() {
   });
 
   it('creates a unique index', function(done) {
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1},
       {unique: true},
       function(error, result) {
@@ -242,7 +243,7 @@ describe('createIndex', function() {
   });
 
   it('creates a sparse index', function(done) {
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1},
       {sparse: true},
       function(error, result) {
@@ -260,7 +261,7 @@ describe('createIndex', function() {
   });
 
   it('creates a hashed index', function(done) {
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 'hashed'},
       function(error, result) {
         if (error) return done(error);
@@ -283,7 +284,7 @@ describe('createIndex', function() {
       name: 'a_1',
       ns: 'fakedb.items'
     });
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 'hashed'},
       function(error, result) {
         if (error) return done(error);
@@ -306,7 +307,7 @@ describe('createIndex', function() {
       name: 'a_hashed',
       ns: 'fakedb.items'
     });
-    mongoose.connection.db.command(
+    harness.dbClient.db('fakedb').command(
       {createIndexes: 'items', indexes: [{key: {a: 'hashed'}}]},
       function(error, results) {
         if (error) return done(error);
@@ -322,7 +323,7 @@ describe('createIndex', function() {
   });
 
   it('accepts custom index name', function(done) {
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1},
       {name: 'totally custom name'},
       function(error, result) {
@@ -345,7 +346,7 @@ describe('createIndex', function() {
       name: 'totally custom name',
       ns: 'fakedb.items'
     });
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1},
       {unique: true},
       function(error) {
@@ -367,7 +368,7 @@ describe('createIndex', function() {
       name: 'totally custom name',
       ns: 'fakedb.items'
     });
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {b: 1},
       {name: 'totally custom name'},
       function(error) {
@@ -386,7 +387,7 @@ describe('createIndex', function() {
   });
 
   it('rejects compound index with a hashed field', function(done) {
-    Item.collection.createIndex(
+    harness.items.createIndex(
       {a: 1, b: 'hashed'},
       function(error) {
         chai.expect(error)

--- a/test/commands/create_indexes_test.js
+++ b/test/commands/create_indexes_test.js
@@ -55,7 +55,6 @@ describe('createIndex', function() {
   // We need this to verify the full output of the createIndexes command.
   // Mongoose only returns the index name.
   it('creates an index using raw command', function(done) {
-    var util = require('util');
     harness.dbClient.db('fakedb').command(
       {createIndexes: 'items', indexes: [{key: {a: 1}}]},
       function(error, results) {

--- a/test/commands/find_test.js
+++ b/test/commands/find_test.js
@@ -9,6 +9,14 @@ var TestHarness = require('../test_harness');
 // Chai uses properties rather than methods for assertions.
 /* eslint-disable no-unused-expressions */
 
+function getProjectionOption(projection) {
+  if (parseInt(mongoose.version.split('.')[0]) <= 4) {
+    return projection;
+  } else {
+    return {projection: projection};
+  }
+}
+
 describe('find', function() {
   var expect = chai.expect;
 
@@ -104,14 +112,16 @@ describe('find', function() {
       {key: 'value', key2: {a: 'b', x: 'y'}, _id: id2},
       {key: 'value', key2: {a: 'c', z: 'x'}, _id: id1}
     ];
-    harness.items.find({key: 'value'}, {projection: {'key2.a': 1}}).toArray(
-      function(error, results) {
-        if (error) return done(error);
+    harness.items.find(
+      {key: 'value'},
+      getProjectionOption({'key2.a': 1})
+    ).toArray(function(error, results) {
+      if (error) return done(error);
 
-        expect(results).to.have.length(2);
-        expect(_.omit(results[0], '_id')).to.deep.equal({key2: {a: 'b'}});
-        expect(_.omit(results[1], '_id')).to.deep.equal({key2: {a: 'c'}});
-        done();
+      expect(results).to.have.length(2);
+      expect(_.omit(results[0], '_id')).to.deep.equal({key2: {a: 'b'}});
+      expect(_.omit(results[1], '_id')).to.deep.equal({key2: {a: 'c'}});
+      done();
     });
   });
 
@@ -180,7 +190,7 @@ describe('find', function() {
   });
 
   it('rejects invalid requested projections', function(done) {
-    harness.items.find({b: 1}, {projection: {a: 1, b: 0}})
+    harness.items.find({b: 1}, getProjectionOption({a: 1, b: 0}))
       .toArray(function(error) {
         expect(error).to.have.property('name', 'MongoError');
         expect(error)

--- a/test/commands/find_test.js
+++ b/test/commands/find_test.js
@@ -18,43 +18,43 @@ describe('find', function() {
 
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
-  var Item;
 
   before(function(done) {
-    harness.setUp(function(error) {
-      Item = mongoose.connection.models.Item;
-      done(error);
+    harness.setUpWithMongoClient(function(error) {
+      if (error) return done(error);
+      harness.items = harness.dbClient.db('fakedb').collection('items');
+      done();
     });
   });
 
   after(function(done) {
-    harness.tearDown(done);
+    harness.tearDownWithMongoClient(done);
   });
 
   it('returns all documents', function(done) {
     fakeDatabase.items = [{key: 'value1'}, {key: 'value2'}];
-    Item.find(function(error, items) {
+    harness.items.find().toArray(function(error, items) {
       if (error) return done(error);
       expect(items).to.have.length(2);
-      expect(items[0].toObject()).to.have.property('key', 'value1');
-      expect(items[1].toObject()).to.have.property('key', 'value2');
+      expect(items[0]).to.have.property('key', 'value1');
+      expect(items[1]).to.have.property('key', 'value2');
       done();
     });
   });
 
   it('returns documents by query', function(done) {
     fakeDatabase.items = [{key: 'value1'}, {key: 'value2'}];
-    Item.find({key: 'value1'}, function(error, items) {
+    harness.items.find({key: 'value1'}).toArray(function(error, items) {
       if (error) return done(error);
       expect(items).to.have.length(1);
-      expect(items[0].toObject()).to.have.property('key', 'value1');
+      expect(items[0]).to.have.property('key', 'value1');
       done();
     });
   });
 
   it('returns no documents from non-existent collections', function(done) {
     delete fakeDatabase.items;
-    Item.find({key: 'value1'}, function(error, items) {
+    harness.items.find({key: 'value1'}).toArray(function(error, items) {
       if (error) return done(error);
       expect(items).to.have.length(0);
       expect(fakeDatabase).to.not.have.property('items');
@@ -64,7 +64,7 @@ describe('find', function() {
 
   it('does not create non-existent collections', function(done) {
     delete fakeDatabase.items;
-    Item.find({key: 'value1'}, function(error) {
+    harness.items.find({key: 'value1'}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase).to.not.have.property('items');
       done();
@@ -75,12 +75,12 @@ describe('find', function() {
   // without waiting for results from the first .
   it('run twice', function(done) {
     fakeDatabase.items = [{key: 'value1'}, {key: 'value2'}];
-    Item.find(function() {});
-    Item.find(function(error, items) {
+    harness.items.find().toArray(function() {});
+    harness.items.find().toArray(function(error, items) {
       if (error) return done(error);
       expect(items).to.have.length(2);
-      expect(items[0].toObject()).to.have.property('key', 'value1');
-      expect(items[1].toObject()).to.have.property('key', 'value2');
+      expect(items[0]).to.have.property('key', 'value1');
+      expect(items[1]).to.have.property('key', 'value2');
       done();
     });
   });
@@ -90,7 +90,7 @@ describe('find', function() {
       {key: 'value', key2: 2, _id: id2},
       {key: 'value', key2: 1, _id: id1}
     ];
-    Item.collection.find({key: 'value'})
+    harness.items.find({key: 'value'})
       .sort({key2: 1})  // Calling sort causes MongoDB client to send $query.
       .toArray(function(error, results) {
         if (error) return done(error);
@@ -104,7 +104,7 @@ describe('find', function() {
       {key: 'value', key2: {a: 'b', x: 'y'}, _id: id2},
       {key: 'value', key2: {a: 'c', z: 'x'}, _id: id1}
     ];
-    Item.collection.find({key: 'value'}, {'key2.a': 1}).toArray(
+    harness.items.find({key: 'value'}, {projection: {'key2.a': 1}}).toArray(
       function(error, results) {
         if (error) return done(error);
 
@@ -121,7 +121,7 @@ describe('find', function() {
       {key: 'value2', key2: 2, _id: id2},
       {key: 'value3', key2: 3, _id: id3}
     ];
-    Item.collection.find({}).skip(1).toArray(function(error, items) {
+    harness.items.find({}).skip(1).toArray(function(error, items) {
       if (error) return done(error);
       expect(items).to.deep.equal(fakeDatabase.items.slice(1));
       done();
@@ -134,7 +134,7 @@ describe('find', function() {
       {key: 'value2', key2: 2, _id: id2},
       {key: 'value3', key2: 3, _id: id3}
     ];
-    Item.collection.find({}).limit(2).toArray(function(error, items) {
+    harness.items.find({}).limit(2).toArray(function(error, items) {
       if (error) return done(error);
       expect(items).to.deep.equal(fakeDatabase.items.slice(0, 2));
       done();
@@ -147,29 +147,31 @@ describe('find', function() {
       {key: 'value2', key2: 2, _id: id2},
       {key: 'value3', key2: 3, _id: id3}
     ];
-    Item.collection.find({}).skip(1).limit(1).toArray(function(error, items) {
+    harness.items.find({}).skip(1).limit(1).toArray(function(error, items) {
       if (error) return done(error);
       expect(items).to.deep.equal(fakeDatabase.items.slice(1, 2));
       done();
     });
   });
 
-  it('supports findById', function(done) {
+  it('supports findOne', function(done) {
     fakeDatabase.items = [
       {key: 'value1', key2: 1, _id: id1},
       {key: 'value2', key2: 2, _id: id2},
       {key: 'value3', key2: 3, _id: id3}
     ];
-    Item.findById(new mongoose.Types.ObjectId(id3), function(error, item) {
-      if (error) return done(error);
-      expect(item).to.exist;
-      expect(item.toObject()).to.deep.equal(fakeDatabase.items[2]);
-      done();
-    });
+    harness.items.findOne(
+      {_id: new mongoose.Types.ObjectId(id3)},
+      function(error, item) {
+        if (error) return done(error);
+        expect(item).to.exist;
+        expect(item).to.deep.equal(fakeDatabase.items[2]);
+        done();
+      });
   });
 
   it('rejects invalid queries', function(done) {
-    Item.collection.find({'$eq': 'value24'}).toArray(function(error) {
+    harness.items.find({'$eq': 'value24'}).toArray(function(error) {
       expect(error)
         .to.have.property('message')
         .to.match(/BadValue unknown top level operator: [$]eq/);
@@ -178,14 +180,15 @@ describe('find', function() {
   });
 
   it('rejects invalid requested projections', function(done) {
-    Item.collection.find({b: 1}, {a: 1, b: 0}).toArray(function(error) {
-      expect(error).to.have.property('name', 'MongoError');
-      expect(error)
-        .to.have.property('message')
-        .to.have.string(
-          'BadValue Projection cannot have ' +
-          'a mix of inclusion and exclusion.');
-      done();
-    });
+    harness.items.find({b: 1}, {projection: {a: 1, b: 0}})
+      .toArray(function(error) {
+        expect(error).to.have.property('name', 'MongoError');
+        expect(error)
+          .to.have.property('message')
+          .to.have.string(
+            'BadValue Projection cannot have ' +
+            'a mix of inclusion and exclusion.');
+        done();
+      });
   });
 });

--- a/test/commands/insert_test.js
+++ b/test/commands/insert_test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var chai = require('chai');
-var mongoose = require('mongoose');
 
 chai.use(require('chai-properties'));
 
@@ -15,12 +14,13 @@ describe('insert', function() {
 
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
-  var Item;
 
   before(function(done) {
     harness.setUp(function(error) {
-      Item = mongoose.connection.models.Item;
-      done(error);
+      if (error) return done(error);
+      harness.items = harness.dbClient.db('fakedb').collection('items');
+      harness.systemIndexes = harness.dbClient.db('fakedb').collection('system.indexes');
+      done();
     });
   });
 
@@ -30,7 +30,7 @@ describe('insert', function() {
 
   it('adds documents to collection', function(done) {
     fakeDatabase.items = [];
-    Item.collection.insert({key: 'value'}, function(error) {
+    harness.items.insert({key: 'value'}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase.items).to.have.length(1);
       expect(fakeDatabase.items[0])
@@ -41,7 +41,7 @@ describe('insert', function() {
 
   it('creates collection if it does not exist', function(done) {
     delete fakeDatabase.items;
-    Item.collection.insert({key: 'value'}, function(error) {
+    harness.items.insert({key: 'value'}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase.items).to.have.length(1);
       expect(fakeDatabase.items[0])
@@ -54,15 +54,9 @@ describe('insert', function() {
     function(done) {
       fakeDatabase['system.indexes'] = [];
 
-      var Index = mongoose.model(
-        'Index',
-        new mongoose.Schema(
-          {any: mongoose.Schema.Types.Mixed},
-          {collection: 'system.indexes', versionKey: false, _id: false}));
-      Index.collection.insert(
+      harness.systemIndexes.insert(
         [{key: {a: 1}, name: 'a_1', v: 1, ns: 'fakedb.items'}],
         function(error, result) {
-          delete mongoose.connection.models.Index;
           if (error) return done(error);
 
           expect(result).to.have.deep.property('result.ok').to.be.ok;

--- a/test/commands/remove_test.js
+++ b/test/commands/remove_test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var chai = require('chai');
-var mongoose = require('mongoose');
 
 var TestHarness = require('../test_harness');
 
@@ -10,12 +9,12 @@ describe('remove', function() {
 
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
-  var Item;
 
   before(function(done) {
     harness.setUp(function(error) {
-      Item = mongoose.connection.models.Item;
-      done(error);
+      if (error) return done(error);
+      harness.items = harness.dbClient.db('fakedb').collection('items');
+      done();
     });
   });
 
@@ -25,7 +24,7 @@ describe('remove', function() {
 
   it('basic', function(done) {
     fakeDatabase.items = [{key: 'value1'}, {key: 'value2'}];
-    Item.remove({key: 'value1'}, function(error) {
+    harness.items.remove({key: 'value1'}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase.items).to.have.length(1);
       expect(fakeDatabase.items[0])
@@ -36,7 +35,7 @@ describe('remove', function() {
 
   it('removes documents by query', function(done) {
     fakeDatabase.items = [{key: 'value1'}, {key: 'value2'}];
-    Item.remove({key: {$ne: 'value1'}}, function(error) {
+    harness.items.remove({key: {$ne: 'value1'}}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase.items).to.have.length(1);
       expect(fakeDatabase.items[0])
@@ -47,7 +46,7 @@ describe('remove', function() {
 
   it('does not create non-existent collection', function(done) {
     delete fakeDatabase.items;
-    Item.remove({key: 'value1'}, function(error) {
+    harness.items.remove({key: 'value1'}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase).to.not.have.property('items');
       done();

--- a/test/commands/update_test.js
+++ b/test/commands/update_test.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 var chai = require('chai');
-var mongoose = require('mongoose');
+var mongodb = require('mongodb');
 
 var TestHarness = require('../test_harness');
 
@@ -12,14 +12,13 @@ var TestHarness = require('../test_harness');
 describe('update', function() {
   var expect = chai.expect;
 
-  var id1 = new mongoose.Types.ObjectId();
-  var id2 = new mongoose.Types.ObjectId();
-
+  var id1 = new mongodb.ObjectId();
+  var id2 = new mongodb.ObjectId(); 
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
 
   before(function(done) {
-    harness.setUpWithMongoClient(function(error) {
+    harness.setUp(function(error) {
       if (error) return done(error);
       harness.items = harness.dbClient.db('fakedb').collection('items');
       done();
@@ -27,7 +26,7 @@ describe('update', function() {
   });
 
   after(function(done) {
-    harness.tearDownWithMongoClient(done);
+    harness.tearDown(done);
   });
 
   it('updates all documents', function(done) {
@@ -292,7 +291,7 @@ describe('update', function() {
   });
 
   it('$pull ObjectIds', function(done) {
-    var idCopy = new mongoose.Types.ObjectId(id1.toString());
+    var idCopy = new mongodb.ObjectId(id1.toString());
     fakeDatabase.items = [{key: [id1]}];
     harness.items.update({}, {$pull: {key: idCopy}}, function(error) {
       if (error) return done(error);

--- a/test/commands/update_test.js
+++ b/test/commands/update_test.js
@@ -114,7 +114,7 @@ describe('update', function() {
     harness.items.update(
       {a: 'value1'},
       {'b.c': 42},
-      function(error, res) {
+      function(error) {
         expect(error).to.have.property('ok').to.be.not.ok;
         expect(error)
           .to.have.property('err')

--- a/test/commands/update_test.js
+++ b/test/commands/update_test.js
@@ -17,22 +17,22 @@ describe('update', function() {
 
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
-  var Item;
 
   before(function(done) {
-    harness.setUp(function(error) {
-      Item = mongoose.connection.models.Item;
-      done(error);
+    harness.setUpWithMongoClient(function(error) {
+      if (error) return done(error);
+      harness.items = harness.dbClient.db('fakedb').collection('items');
+      done();
     });
   });
 
   after(function(done) {
-    harness.tearDown(done);
+    harness.tearDownWithMongoClient(done);
   });
 
   it('updates all documents', function(done) {
     fakeDatabase.items = [{key: 'value1', _id: id1}, {key: 'value2', _id: id2}];
-    Item.collection.update(
+    harness.items.update(
       {},
       {'$set': {key: 'new value'}},
       {multi: true},
@@ -51,7 +51,7 @@ describe('update', function() {
 
   it('updates documents by query', function(done) {
     fakeDatabase.items = [{key: 'value1', _id: id1}, {key: 'value2', _id: id2}];
-    Item.collection.update(
+    harness.items.update(
       {key: 'value2'},
       {'$set': {key: 'new value'}},
       function(error, result) {
@@ -69,7 +69,7 @@ describe('update', function() {
 
   it('updates nothing when query does not match', function(done) {
     fakeDatabase.items = [{key: 'value1', _id: id1}, {key: 'value2', _id: id2}];
-    Item.collection.update(
+    harness.items.update(
       {key: 'value3'},
       {'$set': {key: 'new value'}},
       function(error, result) {
@@ -86,7 +86,7 @@ describe('update', function() {
 
   it('replaces fields', function(done) {
     fakeDatabase.items = [{a: 'value', b: 1, c: 'there', _id: id1}];
-    Item.collection.update(
+    harness.items.update(
       {a: 'value'},
       {a: 'new value', '$inc': {b: 1}},
       function(error) {
@@ -99,7 +99,7 @@ describe('update', function() {
 
   it('replaces subfields', function(done) {
     fakeDatabase.items = [{a: 'value1', b: {c: 1}, _id: id1}];
-    Item.collection.update(
+    harness.items.update(
       {a: 'value1'},
       {'$set': {'b.c': 42}},
       function(error) {
@@ -112,10 +112,12 @@ describe('update', function() {
 
   it('rejects subfield literals', function(done) {
     fakeDatabase.items = [{a: 'value1', b: {c: 1}, _id: id1}];
-    Item.collection.update(
+    harness.items.update(
       {a: 'value1'},
       {'b.c': 42},
-      function(error) {
+      function(error, res) {
+        var util = require('util');
+        console.log(util.format(res));
         expect(error).to.have.property('ok').to.be.not.ok;
         expect(error)
           .to.have.property('err')
@@ -126,7 +128,7 @@ describe('update', function() {
 
   it('replaces entire documents', function(done) {
     fakeDatabase.items = [{a: 'value1', b: 1, _id: id1}];
-    Item.collection.update({a: 'value1'}, {b: 42}, function(error) {
+    harness.items.update({a: 'value1'}, {b: 42}, function(error) {
       if (error) return done(error);
       // The subfield a.c should be gone as the update document does not
       // specify any operators.
@@ -138,7 +140,7 @@ describe('update', function() {
 
   it('does not create non-existent collection', function(done) {
     delete fakeDatabase.items;
-    Item.collection.update({a: 'value1'}, {b: 42}, function(error, result) {
+    harness.items.update({a: 'value1'}, {b: 42}, function(error, result) {
       if (error) return done(error);
 
       expect(result).to.have.deep.property('result.ok').to.be.ok;
@@ -152,7 +154,7 @@ describe('update', function() {
 
   it('$pushAll to array', function(done) {
     fakeDatabase.items = [{_id: id1, key: ['value1']}];
-    Item.collection.update(
+    harness.items.update(
       {_id: id1},
       {'$pushAll': {key: ['value2']}},
       function(error) {
@@ -167,7 +169,7 @@ describe('update', function() {
 
   it('$pushAll to non-existent field creates array', function(done) {
     fakeDatabase.items = [{_id: id1}];
-    Item.collection.update(
+    harness.items.update(
       {},
       {'$pushAll': {key: ['a', 'b']}},
       function(error) {
@@ -182,7 +184,7 @@ describe('update', function() {
 
   it('$pushAll to non-array fails', function(done) {
     fakeDatabase.items = [{key: {a: 1}}];
-    Item.collection.update(
+    harness.items.update(
       {},
       {'$pushAll': {'key': ['a']}},
       function(error) {
@@ -200,7 +202,7 @@ describe('update', function() {
 
   it('$pushAll with non-array argument fails', function(done) {
     fakeDatabase.items = [{key: ['value1', 'value2']}];
-    Item.collection.update(
+    harness.items.update(
       {},
       {'$pushAll': {key: 'abc'}},
       function(error) {
@@ -220,7 +222,7 @@ describe('update', function() {
 
   it('set array value', function(done) {
     fakeDatabase.items = [{_id: id1, key: ['value1', 'value2']}];
-    Item.collection.update(
+    harness.items.update(
       {_id: id1},
       {'$set': {key: ['one', 'two']}},
       function(error, result) {
@@ -239,13 +241,13 @@ describe('update', function() {
     var tenSecondsAgo = new Date(Date.now() - 10 * 1000);
     var now = new Date();
     fakeDatabase.items = [{_id: id1, date: tenSecondsAgo}];
-    Item.findOne({_id: id1}, function(error, item) {
+    harness.items.findOne({_id: id1}, function(error, item) {
       if (error) return done(error);
-      expect(item.toObject())
+      expect(item)
         .to.have.property('date')
         .to.be.instanceof(Date)
         .and.to.eql(tenSecondsAgo);
-      Item.collection.update({}, {'$set': {date: now}}, function(error) {
+      harness.items.update({}, {'$set': {date: now}}, function(error) {
         if (error) return done(error);
         expect(fakeDatabase.items).to.have.length(1);
         expect(fakeDatabase.items[0])
@@ -261,7 +263,7 @@ describe('update', function() {
     var tenSecondsAgo = new Date(Date.now() - 10 * 1000);
     var now = new Date();
     fakeDatabase.items = [{_id: id1, date: tenSecondsAgo}];
-    Item.collection.update({}, {$set: {date: [now]}}, function(error) {
+    harness.items.update({}, {$set: {date: [now]}}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase.items).to.have.length(1);
       expect(fakeDatabase.items[0])
@@ -276,7 +278,7 @@ describe('update', function() {
 
   it('$pull', function(done) {
     fakeDatabase.items = [{_id: id1, key: ['value1', 'value2']}];
-    Item.collection.update(
+    harness.items.update(
       {},
       {$pull: {key: 'value1'}},
       function(error) {
@@ -292,7 +294,7 @@ describe('update', function() {
   it('$pull ObjectIds', function(done) {
     var idCopy = new mongoose.Types.ObjectId(id1.toString());
     fakeDatabase.items = [{key: [id1]}];
-    Item.collection.update({}, {$pull: {key: idCopy}}, function(error) {
+    harness.items.update({}, {$pull: {key: idCopy}}, function(error) {
       if (error) return done(error);
       expect(fakeDatabase.items).to.have.length(1);
       expect(fakeDatabase.items[0])
@@ -307,7 +309,7 @@ describe('update', function() {
       key: ['a', 'b'],
       key2: ['c', 'd']
     }];
-    Item.collection.update(
+    harness.items.update(
       {},
       {$pull: {key: 'a', key2: 'd'}},
       function(error) {
@@ -325,7 +327,7 @@ describe('update', function() {
 
   it('$pull by query removes multiple values', function(done) {
     fakeDatabase.items = [{_id: id1, key: [1, 11, 2, 12, 3, 13, 4]}];
-    Item.collection.update(
+    harness.items.update(
       {},
       {$pull: {key: {'$gt': 10}}},
       function(error) {
@@ -340,7 +342,7 @@ describe('update', function() {
 
   it('$pull by query removes repeated values', function(done) {
     fakeDatabase.items = [{_id: id1, key: [1, 13, 2, 13, 3, 13]}];
-    Item.collection.update(
+    harness.items.update(
       {},
       {$pull: {key: {'$gt': 10}}},
       function(error) {
@@ -355,7 +357,7 @@ describe('update', function() {
 
   it('$pull by query works with subfields', function(done) {
     fakeDatabase.items = [{_id: id1, key: {a: [1, 2, 10, 20]}}];
-    Item.collection.update(
+    harness.items.update(
       {},
       {$pull: {'key.a': {'$lt': 10}}},
       function(error) {
@@ -373,7 +375,7 @@ describe('update', function() {
       _id: id1,
       key: [{a: 1}, {a: 2}, {a: 10}, {a: 20}]
     }];
-    Item.collection.update(
+    harness.items.update(
       {},
       {$pull: {'key': {a: {'$lt': 10}}}},
       function(error) {
@@ -392,7 +394,7 @@ describe('update', function() {
         _id: id1,
         key: [{a: 5}, {a: 15}, {a: 25}]
       }];
-      Item.collection.update(
+      harness.items.update(
         {},
         {$pull: {key: {'$or': [{a: {'$lt': 10}}, {a: {'$gt': 20}}]}}},
         function(error) {
@@ -407,7 +409,7 @@ describe('update', function() {
 
   it('$pull from non-array fails', function(done) {
     fakeDatabase.items = [{key: ['value1', 'value2']}];
-    Item.collection.update(
+    harness.items.update(
       {},
       {$pull: {'key.1': 'a'}},
       function(error) {
@@ -425,7 +427,7 @@ describe('update', function() {
 
   it('with non-container in path fails', function(done) {
     fakeDatabase.items = [{key: 'value1'}];
-    Item.collection.update(
+    harness.items.update(
       {key: 'value1'},
       {$set: {'key.k2.k3': 5}},
       function(error) {
@@ -441,7 +443,7 @@ describe('update', function() {
 
   it('rejects invalid filters', function(done) {
     fakeDatabase.items = [{key: 'value1'}];
-    Item.collection.update(
+    harness.items.update(
       {'$eq': 2},
       {$set: {'value': 5}},
       function(error) {
@@ -456,7 +458,7 @@ describe('update', function() {
   describe('$unset', function() {
     it('deletes fields', function(done) {
       fakeDatabase.items = [{a: 'value1', b: 33, _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {_id: id1},
         {'$unset': {b: 0}},
         function(error) {
@@ -470,7 +472,7 @@ describe('update', function() {
 
     it('deletes compound fields', function(done) {
       fakeDatabase.items = [{a: 'value1', b: {c: 1}, _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {_id: id1},
         {'$unset': {b: 0}},
         function(error) {
@@ -487,7 +489,7 @@ describe('update', function() {
         a: 'value1',
         b: {c: 1, d: 2},
         _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {_id: id1},
         {'$unset': {'b.c': 0}},
         function(error) {
@@ -501,7 +503,7 @@ describe('update', function() {
 
     it('deletes multiple fields', function(done) {
       fakeDatabase.items = [{a: 'value1', b: 33, _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {_id: id1},
         {'$unset': {a: 'value ignored', b: 0}},
         function(error) {
@@ -515,7 +517,7 @@ describe('update', function() {
 
     it('ignores non-existing fields', function(done) {
       fakeDatabase.items = [{a: 'value1', b: 33, _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {_id: id1},
         {'$unset': {c: 0}},
         function(error) {
@@ -533,7 +535,7 @@ describe('update', function() {
         b: {c: 1, d: {x: 2}},
         _id: id1
       }];
-      Item.collection.update(
+      harness.items.update(
         {_id: id1},
         {'$unset': {'b.h': 0, 'b.d.y': 0}},
         function(error) {
@@ -547,7 +549,7 @@ describe('update', function() {
 
     it('ignores subfields of non-objects', function(done) {
       fakeDatabase.items = [{a: 'value1', _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {_id: id1},
         {'$unset': {'a.f': 0}},
         function(error) {
@@ -565,7 +567,7 @@ describe('update', function() {
         b: [1, 2, 3],
         _id: id1
       }];
-      Item.collection.update(
+      harness.items.update(
         {_id: id1},
         {'$unset': {'b.1': 0}},
         function(error) {
@@ -583,7 +585,7 @@ describe('update', function() {
         b: [1, 2, 3],
         _id: id1
       }];
-      Item.collection.update(
+      harness.items.update(
         {_id: id1},
         {'$unset': {'b.8': 0}},
         function(error) {
@@ -599,7 +601,7 @@ describe('update', function() {
   describe('upsert', function() {
     it('updates existing documents', function(done) {
       fakeDatabase.items = [{a: 'value', b: 1, _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {a: 'value'},
         {'$set': {a: 'new value'}, '$inc': {b: 10}},
         {upsert: true},
@@ -613,7 +615,7 @@ describe('update', function() {
 
     it('inserts new document when no matches', function(done) {
       fakeDatabase.items = [{a: 'value1', b: 1, _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {a: 'value2'},
         {b: 10},
         {upsert: true},
@@ -632,7 +634,7 @@ describe('update', function() {
 
     it('creates a collection if does not exist when inserting', function(done) {
       delete fakeDatabase.items;
-      Item.collection.update(
+      harness.items.update(
         {a: 'value2'},
         {b: 10},
         {upsert: true},
@@ -650,7 +652,7 @@ describe('update', function() {
     it('uses only update document values if update contains no operators',
       function(done) {
         fakeDatabase.items = [{a: 'value1', b: 1, _id: id1}];
-        Item.collection.update(
+        harness.items.update(
           {a: 'value2'},
           {b: 10, c: 'whatever'},
           {upsert: true},
@@ -671,7 +673,7 @@ describe('update', function() {
     it('uses update and find document values if update contains operators',
       function(done) {
         fakeDatabase.items = [{a: 'value1', b: 1, _id: id1}];
-        Item.collection.update(
+        harness.items.update(
           {a: 'value2', b: {'$gt': 5}},
           {'$set': {c: 10}, d: 'whatever'},
           {upsert: true},
@@ -694,7 +696,7 @@ describe('update', function() {
     it('pulls values from $and conjunctions if update contains operators',
       function(done) {
         fakeDatabase.items = [{a: 'value1', b: 1, _id: id1}];
-        Item.collection.update(
+        harness.items.update(
           {'$and': [
             {a: 'value2', b: 18},
             {'$and': [{c: 42}, {'d.e': 36}]},
@@ -724,7 +726,7 @@ describe('update', function() {
 
     it('does not unpack ObjectIDs when copying from query', function(done) {
       fakeDatabase.items = [{a: 'value1', _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {a: 'value2', b: id2},
         {'$set': {c: 10}},
         {upsert: true},
@@ -745,7 +747,7 @@ describe('update', function() {
 
     it('$setOnInsert modifies inserted records', function(done) {
       fakeDatabase.items = [{a: 'value1', _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {a: 'value2'},
         {'$setOnInsert': {c: 10}},
         {upsert: true},
@@ -764,7 +766,7 @@ describe('update', function() {
 
     it('$setOnInsert does not touch updated records', function(done) {
       fakeDatabase.items = [{a: 'value1', _id: id1}];
-      Item.collection.update(
+      harness.items.update(
         {a: 'value1'},
         {'$setOnInsert': {c: 10}, '$set': {b: 5}},
         {upsert: true},
@@ -785,7 +787,7 @@ describe('update', function() {
         {a: 'value', b: 1, _id: id1},
         {a: 'value', b: 2, _id: id2}
       ];
-      Item.collection.update(
+      harness.items.update(
         {a: 'value'},
         {'$set': {a: 'new value'}, '$inc': {b: 10}},
         function(error) {
@@ -804,7 +806,7 @@ describe('update', function() {
         {a: 'value', b: 1, _id: id1},
         {a: 'value', b: 2, _id: id2}
       ];
-      Item.collection.update(
+      harness.items.update(
         {a: 'value'},
         {'$set': {a: 'new value'}, '$inc': {b: 10}},
         {multi: false},
@@ -824,7 +826,7 @@ describe('update', function() {
         {a: 'value', b: 1, _id: id1},
         {a: 'value', b: 2, _id: id2}
       ];
-      Item.collection.update(
+      harness.items.update(
         {a: 'value'},
         {'$set': {a: 'new value'}, '$inc': {b: 10}},
         {multi: true},
@@ -844,7 +846,7 @@ describe('update', function() {
         {a: 'value', b: 1, _id: id1},
         {a: 'value', b: 2, _id: id2}
       ];
-      Item.collection.update(
+      harness.items.update(
         {a: 'value'},
         {a: 'new value', '$inc': {b: 10}},
         {multi: true},

--- a/test/commands/update_test.js
+++ b/test/commands/update_test.js
@@ -13,7 +13,7 @@ describe('update', function() {
   var expect = chai.expect;
 
   var id1 = new mongodb.ObjectId();
-  var id2 = new mongodb.ObjectId(); 
+  var id2 = new mongodb.ObjectId();
   var fakeDatabase = {};
   var harness = new TestHarness({fakedb: fakeDatabase});
 
@@ -115,8 +115,6 @@ describe('update', function() {
       {a: 'value1'},
       {'b.c': 42},
       function(error, res) {
-        var util = require('util');
-        console.log(util.format(res));
         expect(error).to.have.property('ok').to.be.not.ok;
         expect(error)
           .to.have.property('err')

--- a/test/filter_test.js
+++ b/test/filter_test.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 var chai = require('chai');
-var mongoose = require('mongoose');
+var mongodb = require('mongodb');
 var path = require('path');
 var bson = require('bson');
 
@@ -1291,8 +1291,8 @@ describe('filterItems', function() {
     var id4Copy = new bson.ObjectID(id4.toString());
     var id5Copy = new bson.ObjectID(id5.toString());
 
-    var id1DifferentType = new mongoose.Types.ObjectId(id1.toHexString());
-    var id3DifferentType = new mongoose.Types.ObjectId(id3.toHexString());
+    var id1DifferentType = new mongodb.ObjectId(id1.toHexString());
+    var id3DifferentType = new mongodb.ObjectId(id3.toHexString());
 
     var items = [
       {_id: 1, id: id1, ids: [id3, id4]},

--- a/test/multiple_instances_test.js
+++ b/test/multiple_instances_test.js
@@ -14,8 +14,6 @@ var logConfig = {
 /* eslint-disable no-unused-expressions */
 
 describe('Multi-instance support', function() {
-  var ModelOne;
-  var ModelTwo;
   var databaseOne = {
     collectionOne: [{_id: new mongodb.ObjectId(), key: 'value'}]
   };
@@ -38,11 +36,6 @@ describe('Multi-instance support', function() {
   var collectionTwo;
 
   before(function(done) {
-    var serverOptions = {
-      server: {poolSize: 1},
-      useMongoClient: true
-    };
-
     serverOne.start(function(error) {
       if (error) return done(error);
       serverTwo.start(function(error) {
@@ -52,7 +45,7 @@ describe('Multi-instance support', function() {
 
         mongodb.MongoClient.connect(
           'mongodb://localhost:27027/fakedbone',
-          function(err, client) {
+          function(error, client) {
             if (error) {
               return serverTwo.stop(function() {
                 serverOne.stop(function() { done(error) });
@@ -62,7 +55,7 @@ describe('Multi-instance support', function() {
             collectionOne = client.db('fakedbone').collection('collectionOne');
             mongodb.MongoClient.connect(
               'mongodb://localhost:27028/fakedbtwo',
-              function(err, client) {
+              function(error, client) {
                 if (error) {
                   return clientOne.close(function() {
                     serverTwo.stop(function() {
@@ -85,7 +78,7 @@ describe('Multi-instance support', function() {
         serverOne.stop(function() {
           serverTwo.stop(done);
         });
-      })
+      });
     });
   });
 
@@ -96,8 +89,8 @@ describe('Multi-instance support', function() {
       collectionTwo.insert(result, function(error) {
         if (error) return done(error);
         chai.expect(databaseTwo.collectionTwo).to.have.length(1);
-        chai.expect(databaseTwo.collectionTwo[0])
-          .to.have.property('key', 'value');
+        chai.expect(databaseTwo.collectionTwo[0]).
+          to.have.property('key', 'value');
         done();
       });
     });

--- a/test/multiple_instances_test.js
+++ b/test/multiple_instances_test.js
@@ -40,7 +40,7 @@ describe('Multi-instance support', function() {
       if (error) return done(error);
       serverTwo.start(function(error) {
         if (error) {
-          return serverOne.stop(function() { done(error) });
+          return serverOne.stop(function() { done(error); });
         }
 
         mongodb.MongoClient.connect(
@@ -48,7 +48,7 @@ describe('Multi-instance support', function() {
           function(error, client) {
             if (error) {
               return serverTwo.stop(function() {
-                serverOne.stop(function() { done(error) });
+                serverOne.stop(function() { done(error); });
               });
             }
             clientOne = client;
@@ -59,7 +59,7 @@ describe('Multi-instance support', function() {
                 if (error) {
                   return clientOne.close(function() {
                     serverTwo.stop(function() {
-                      serverOne.stop(function() { done(error) });
+                      serverOne.stop(function() { done(error); });
                     });
                   });
                 }
@@ -68,7 +68,7 @@ describe('Multi-instance support', function() {
                 done();
             });
         });
-      })
+      });
     });
   });
 

--- a/test/multiple_instances_test.js
+++ b/test/multiple_instances_test.js
@@ -33,10 +33,10 @@ describe('Multi-instance support', function() {
   });
 
   before(function(done) {
-    var connectionOne = mongoose.createConnection();
-    var connectionTwo = mongoose.createConnection();
-
-    var serverOptions = {server: {poolSize: 1}};
+    var serverOptions = {
+      server: {poolSize: 1},
+      useMongoClient: true
+    };
 
     serverOne.start(function(error) {
       if (error) return done(error);

--- a/test/test_harness.js
+++ b/test/test_harness.js
@@ -35,7 +35,7 @@ TestHarness.prototype.setUp = function setUp(done) {
 
     mongodb.MongoClient.connect(
       connectUrl,
-      function(err, client) {
+      function(error, client) {
         if (error) {
           return mongodbFs.stop(function() { done(error); });
         }

--- a/test/test_harness.js
+++ b/test/test_harness.js
@@ -17,7 +17,7 @@ function TestHarness(mocks, port, logLevel) {
   this.initialized = false;
 }
 
-TestHarness.prototype.setUp = function setUpWithMongoClient(done) {
+TestHarness.prototype.setUp = function setUp(done) {
   mongodbFs.init(this.config);
   if (this.initialized) {
     return process.nextTick(done);
@@ -45,7 +45,7 @@ TestHarness.prototype.setUp = function setUpWithMongoClient(done) {
   }.bind(this));
 };
 
-TestHarness.prototype.tearDown = function tearDownWithMongoClient(done) {
+TestHarness.prototype.tearDown = function tearDown(done) {
   this.initialized = false;
   this.logger.info('Disconnecting...');
   this.dbClient.close(function() {


### PR DESCRIPTION
This change adds compatibility with MongoDB driver 3.x (and thus Mongoose 5.x) into the library.

The PR also removes Mongoose from the test, mainly because Mongoose performs its own validation on the client side, preventing the tests from checking the server side validation.

Best viewed with whitespace diffs [suppressed](https://github.com/vladlosev/mongodb-fs/pull/55/files?w=1).